### PR TITLE
BUG: Value array goes to 4096 not 255.

### DIFF
--- a/src/metaTypes.h
+++ b/src/metaTypes.h
@@ -183,6 +183,7 @@ const char MET_InterpolationTypeName[MET_NUM_INTERPOLATION_TYPES][17] = {
    {'M','E','T','_','L','I','N','E','A','R','\0',' ',' ',' ',' ',' ',' '}};
 
 
+#define MET_MAX_NUMBER_OF_FIELD_VALUES 4096
 //
 //
 // Structure used to define a field
@@ -198,7 +199,8 @@ typedef struct
    bool           defined;    // Has this field already been defined in the
                               //    MetaFile being parsed
    int            length;     // Actual/expect length of an array
-   double         value[4096]; // Memory and pointers for the field's value(s).
+   double         value[MET_MAX_NUMBER_OF_FIELD_VALUES];
+                              // Memory and pointers for the field's value(s).
    bool           terminateRead;  // Set to true if field indicates end of
                                   //   meta data
    } MET_FieldRecordType;

--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -374,7 +374,7 @@ bool MET_InitWriteField(MET_FieldRecordType * _mf,
   if(_type == MET_FLOAT_MATRIX)
     {
     size_t i;
-    for(i=0; i < 255 && i < _length*_length; i++)
+    for(i=0; i < MET_MAX_NUMBER_OF_FIELD_VALUES && i < _length*_length; i++)
       {
       _mf->value[i] = (double)(_v[i]);
       }
@@ -382,7 +382,7 @@ bool MET_InitWriteField(MET_FieldRecordType * _mf,
   else if(_type != MET_STRING)
     {
     size_t i;
-    for(i=0; i < 255 && i < _length; i++)
+    for(i=0; i < MET_MAX_NUMBER_OF_FIELD_VALUES && i < _length; i++)
       {
       _mf->value[i] = (double)(_v[i]);
       }


### PR DESCRIPTION
The InitWriteField function was limiting matrix and vector number of elements to 255, even though 4096 values are supported by the data structure.
