### PR TITLE
Fixed a bunch of minor warnings from clang

### DIFF
--- a/src/metaBlob.cxx
+++ b/src/metaBlob.cxx
@@ -45,7 +45,7 @@ BlobPnt::
 ~BlobPnt()
 {
   delete []m_X;
-};
+}
 
 //
 // MedImage Constructors

--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -2172,6 +2172,7 @@ METAIO_STL::string MetaCommand::TypeToString(TypeEnumType type)
       return "file";
     case ENUM:
       return "enum";
+    case CHAR:
     default:
       return "not defined";
     }

--- a/src/metaContour.h
+++ b/src/metaContour.h
@@ -72,7 +72,7 @@ public:
   ~ContourInterpolatedPnt()
     {
     delete []m_X;
-    };
+    }
 
   unsigned int m_Dim;
   float* m_X;

--- a/src/metaEvent.h
+++ b/src/metaEvent.h
@@ -35,19 +35,19 @@ class METAIO_EXPORT MetaEvent
 
 public:
 
-  MetaEvent(){m_Level = -1;};
-  virtual ~MetaEvent(){};
+  MetaEvent(){m_Level = -1;}
+  virtual ~MetaEvent(){}
 
   virtual void SetCurrentIteration(unsigned int n) {m_CurrentIteration = n;}
   virtual void StartReading(unsigned int n)
     {
     m_NumberOfIterations = n;
     m_Level++;
-    };
+    }
   virtual void StopReading()
     {
     m_Level--;
-    };
+    }
 
 protected:
 

--- a/src/metaImageUtils.cxx
+++ b/src/metaImageUtils.cxx
@@ -17,7 +17,7 @@
 #endif
 
 
-#include "metaImageTypes.h"
+#include "metaImageUtils.h"
 #include <string.h>
 
 #if (METAIO_USE_NAMESPACE)

--- a/src/metaLandmark.cxx
+++ b/src/metaLandmark.cxx
@@ -45,7 +45,7 @@ LandmarkPnt::
 ~LandmarkPnt()
 {
   delete []m_X;
-};
+}
 
 //
 // MedImage Constructors

--- a/src/metaMesh.h
+++ b/src/metaMesh.h
@@ -105,7 +105,7 @@ public:
     }
   ~MeshCellLink()
     {
-    };
+    }
 
   int m_Id; // id of the cell link
   METAIO_STL::list<int> m_Links;
@@ -122,7 +122,7 @@ public:
     }
   virtual ~MeshDataBase()
     {
-    };
+    }
 
   virtual void Write( METAIO_STREAM::ofstream* stream) = 0;
   virtual unsigned int GetSize(void) = 0;
@@ -143,7 +143,7 @@ class METAIO_EXPORT MeshData : public MeshDataBase
 public:
 
   MeshData() {m_Id=-1;}
-  ~MeshData() {};
+  ~MeshData() {}
 
   virtual MET_ValueEnumType GetMetaType()
     {

--- a/src/metaOutput.cxx
+++ b/src/metaOutput.cxx
@@ -386,6 +386,7 @@ METAIO_STL::string MetaOutput::TypeToString(TypeEnumType type)
       return "flag";
     case BOOL:
       return "boolean";
+    case CHAR:
     default:
       return "not defined";
     }

--- a/src/metaOutput.h
+++ b/src/metaOutput.h
@@ -34,7 +34,7 @@ class MetaOutputStream
   public:
 
     MetaOutputStream();
-    virtual ~MetaOutputStream() {};
+    virtual ~MetaOutputStream() {}
 
     void                     SetName(const char* name);
     METAIO_STL::string       GetName() const;
@@ -70,7 +70,7 @@ class MetaFileOutputStream : public MetaOutputStream
   public:
 
     MetaFileOutputStream(const char* name);
-    virtual ~MetaFileOutputStream() {};
+    virtual ~MetaFileOutputStream() {}
 
     bool Open();
     bool Close();

--- a/src/metaTubeGraph.h
+++ b/src/metaTubeGraph.h
@@ -54,7 +54,7 @@ public:
   ~TubeGraphPnt()
   {
     delete [] m_T;
-  };
+  }
 
   unsigned int m_Dim;
   int    m_GraphNode;

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -317,6 +317,8 @@ bool MET_ValueToDouble(MET_ValueEnumType _type, const void *_data,
     case MET_STRING:
       *_value = atof(&(((const MET_CHAR_TYPE *)_data)[_index]));
       return true;
+    case MET_NONE:
+    case MET_OTHER:
     default:
       *_value = 0;
       return false;
@@ -383,6 +385,8 @@ bool MET_DoubleToValue(double _value,
     case MET_STRING:
       sprintf(&(((MET_CHAR_TYPE *)_data)[_index]), "%f", _value);
       return true;
+    case MET_NONE:
+    case MET_OTHER:
     default:
       return false;
     }
@@ -463,6 +467,8 @@ bool MET_ValueToValue(MET_ValueEnumType _fromType, const void *_fromData,
     case MET_STRING:
       sprintf(&(((MET_CHAR_TYPE *)_toData)[_index]), "%f", tf);
       return true;
+    case MET_NONE:
+    case MET_OTHER:
     default:
       return false;
     }
@@ -1673,6 +1679,8 @@ bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
         f.value[i] = (double)((const MET_FLOAT_TYPE *)_v)[i];
         }
       break;
+    case MET_NONE:
+    case MET_OTHER:
     default:
       break;
     }


### PR DESCRIPTION
The C++ files now build cleanly with:

-Weverything -Wno-padded -Wno-old-style-cast -Wno-weak-vtables -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wno-exit-time-destructors -Wno-global-constructors -Wno-float-equal -Wno-conversion -Wno-sign-conversion -Wundefined-bool-conversion -Wstring-conversion -Wno-covered-switch-default -Wno-format-nonliteral