### PR TITLE
BUG: The Radius parameter was not being pushed

### DIFF
--- a/src/metaGaussian.cxx
+++ b/src/metaGaussian.cxx
@@ -146,10 +146,10 @@ M_SetupWriteFields(void)
 
   mF = new MET_FieldRecordType;
   MET_InitWriteField(mF, "Radius", MET_FLOAT, m_Radius);
-
+  m_Fields.push_back(mF);
+  
   mF = new MET_FieldRecordType;
   MET_InitWriteField(mF, "Sigma", MET_FLOAT, m_Sigma);
-
   m_Fields.push_back(mF);
 
 }


### PR DESCRIPTION
After the recent cahnge to include the Sigma parameter the Radius
parameter failed to be included in the fields for writing.