### PR TITLE
metaObject.h: avoid using a single underscore followed by a capital letter

### DIFF
--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -225,7 +225,7 @@ class METAIO_EXPORT MetaObject
       //    Name(...)
       //       Optional Field
       //       Name of the current metaObject
-      void  Name(const char *_Name);
+      void  Name(const char *_name);
       const char  * Name(void) const;
 
       //    Color(...)
@@ -273,7 +273,7 @@ class METAIO_EXPORT MetaObject
 
       void ClearAdditionalFields(void);
 
-      bool InitializeEssential(int _NDims);
+      bool InitializeEssential(int _nDims);
 
       //
       //


### PR DESCRIPTION
This fix is in reference to VTK bug report 0015529.