### PR TITLE
whitespace: remove extra newlines at the end of files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,4 +50,3 @@ else()
 endif()
 
 ADD_SUBDIRECTORY( src )
-

--- a/itkMetaIOConfig.h
+++ b/itkMetaIOConfig.h
@@ -17,4 +17,3 @@
 #undef METAIO_FOR_VTK
 
 #define METAIO_FOR_ITK 1
-

--- a/src/metaArray.cxx
+++ b/src/metaArray.cxx
@@ -1267,4 +1267,3 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data,
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -2454,4 +2454,3 @@ bool MetaCommand::SetOptionValue(const char* optionName,
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaContour.cxx
+++ b/src/metaContour.cxx
@@ -923,4 +923,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaDTITube.cxx
+++ b/src/metaDTITube.cxx
@@ -784,4 +784,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaEllipse.cxx
+++ b/src/metaEllipse.cxx
@@ -218,4 +218,3 @@ M_Read(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaForm.cxx
+++ b/src/metaForm.cxx
@@ -1005,4 +1005,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaGaussian.cxx
+++ b/src/metaGaussian.cxx
@@ -196,4 +196,3 @@ M_Read(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaGroup.cxx
+++ b/src/metaGroup.cxx
@@ -152,4 +152,3 @@ M_Read(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaImageUtils.cxx
+++ b/src/metaImageUtils.cxx
@@ -52,4 +52,3 @@ bool MET_ImageModalityToString(MET_ImageModalityEnumType _type,
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaLandmark.cxx
+++ b/src/metaLandmark.cxx
@@ -492,4 +492,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaLine.cxx
+++ b/src/metaLine.cxx
@@ -528,4 +528,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -1964,4 +1964,3 @@ void MetaObject::M_PrepareNewReadStream()
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaScene.cxx
+++ b/src/metaScene.cxx
@@ -572,4 +572,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaSurface.cxx
+++ b/src/metaSurface.cxx
@@ -497,4 +497,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaTransform.cxx
+++ b/src/metaTransform.cxx
@@ -555,4 +555,3 @@ M_Read(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaTube.cxx
+++ b/src/metaTube.cxx
@@ -860,4 +860,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaTubeGraph.cxx
+++ b/src/metaTubeGraph.cxx
@@ -587,4 +587,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -1777,4 +1777,3 @@ void MET_SwapByteIfSystemMSB(void* val, MET_ValueEnumType _type)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-

--- a/src/metaVesselTube.cxx
+++ b/src/metaVesselTube.cxx
@@ -1151,4 +1151,3 @@ M_Write(void)
 #if (METAIO_USE_NAMESPACE)
 };
 #endif
-


### PR DESCRIPTION
---
@bradking @thewtex Another warning VTK might warn about. Manually done with `vim src/*(.)`.