### PR TITLE
COMP: Fixed the warning messages of ITK on VS14.

### DIFF
--- a/src/metaBlob.cxx
+++ b/src/metaBlob.cxx
@@ -134,12 +134,12 @@ PointDim(void) const
 }
 
 void MetaBlob::
-NPoints(int npnt)
+NPoints(size_t npnt)
 {
   m_NPoints = npnt;
 }
 
-int MetaBlob::
+size_t MetaBlob::
 NPoints(void) const
 {
   return m_NPoints;
@@ -328,7 +328,7 @@ M_Read(void)
   {
     int elementSize;
     MET_SizeOfType(m_ElementType, &elementSize);
-    int readSize = m_NPoints*(m_NDims+4)*elementSize;
+    size_t readSize = m_NPoints*(m_NDims+4)*elementSize;
 
     char* _data = new char[readSize];
     m_ReadStream->read((char *)_data, readSize);

--- a/src/metaBlob.h
+++ b/src/metaBlob.h
@@ -90,8 +90,8 @@ class METAIO_EXPORT MetaBlob : public MetaObject
     //    NPoints(...)
     //       Required Field
     //       Number of points wich compose the blob
-    void  NPoints(int npnt);
-    int   NPoints(void) const;
+    void  NPoints(size_t npnt);
+    size_t  NPoints(void) const;
 
     //    PointDim(...)
     //       Required Field
@@ -127,7 +127,7 @@ class METAIO_EXPORT MetaBlob : public MetaObject
 
     bool  M_Write(void);
 
-    int   m_NPoints;      // "NPoints = "         0
+    size_t  m_NPoints;      // "NPoints = "         0
 
     char m_PointDim[255]; // "PointDim = "       "x y z r"
 


### PR DESCRIPTION
- Changed the data-type of 'm_NPoints' from 'int' to 'size_t' to avoid the
  ITK warning message of "Warning C4267 conversion from 'size_t' to 'int'
  on VS14.

- Also, the argument data-type of "void NPoints(int npnt)" was changed to
  "void NPoint(size_t npt)" to remove the above warning message.

- The return value type of "int NPoints(void)" was replaced with "size_t
  NPoints(void).