### PR TITLE
COMP: Overload the function of NPoints to avoid data-conversion warning message.

### DIFF
--- a/src/metaBlob.cxx
+++ b/src/metaBlob.cxx
@@ -134,12 +134,18 @@ PointDim(void) const
 }
 
 void MetaBlob::
-NPoints(size_t npnt)
+NPoints(int npnt)
 {
   m_NPoints = npnt;
 }
 
-size_t MetaBlob::
+void MetaBlob::
+NPoints(size_t npnt)
+{
+  m_NPoints = static_cast<int>(npnt);
+}
+
+int MetaBlob::
 NPoints(void) const
 {
   return m_NPoints;
@@ -328,7 +334,7 @@ M_Read(void)
   {
     int elementSize;
     MET_SizeOfType(m_ElementType, &elementSize);
-    size_t readSize = m_NPoints*(m_NDims+4)*elementSize;
+    int readSize = m_NPoints*(m_NDims+4)*elementSize;
 
     char* _data = new char[readSize];
     m_ReadStream->read((char *)_data, readSize);

--- a/src/metaBlob.h
+++ b/src/metaBlob.h
@@ -90,8 +90,10 @@ class METAIO_EXPORT MetaBlob : public MetaObject
     //    NPoints(...)
     //       Required Field
     //       Number of points wich compose the blob
+    void  NPoints(int npnt);
+    // Overloaded function to avoid data-cast warning message
     void  NPoints(size_t npnt);
-    size_t  NPoints(void) const;
+    int  NPoints(void) const;
 
     //    PointDim(...)
     //       Required Field
@@ -127,7 +129,7 @@ class METAIO_EXPORT MetaBlob : public MetaObject
 
     bool  M_Write(void);
 
-    size_t  m_NPoints;      // "NPoints = "         0
+    int  m_NPoints;      // "NPoints = "         0
 
     char m_PointDim[255]; // "PointDim = "       "x y z r"
 


### PR DESCRIPTION
- To avoid the warning message of "conversion from size_t to int" on VS14,
  create an overloaded function of 'void NPoint(size_t npnt)'.

- Removed all changes of the previous patch.
  (see https://github.com/Kitware/MetaIO/pull/18)