### PR TITLE
BUG: Missing one case in MET_SetFileSuffix

### DIFF
--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -950,6 +950,10 @@ bool MET_SetFileSuffix(char *_fName, const char *_suf)
     }
   else
     {
+    if( _suf[0] != '.')
+      {
+      strcat(_fName, ".");
+      }
     strcat(_fName, _suf);
     return true;
     }

--- a/src/tests/testMeta1Utils.cxx
+++ b/src/tests/testMeta1Utils.cxx
@@ -104,7 +104,31 @@ int main(int, char * [])
   else
     METAIO_STREAM::cout << "PASSED" << METAIO_STREAM::endl;
 
-  METAIO_STREAM::cout << "MET_SetFileSuffix: ";
+  METAIO_STREAM::cout << "MET_SetFileSuffix: 1:";
+  MET_SetFileSuffix(fName, ".net");
+  if(strcmp(fName, "this/is/a/test.net"))
+    METAIO_STREAM::cout << "FAILED" << METAIO_STREAM::endl;
+  else
+    METAIO_STREAM::cout << "PASSED" << METAIO_STREAM::endl;
+
+  sprintf(fName, "this/is/a/test.com"); // Only necessary if previous test fails
+  METAIO_STREAM::cout << "MET_SetFileSuffix: 2:";
+  MET_SetFileSuffix(fName, "net");
+  if(strcmp(fName, "this/is/a/test.net"))
+    METAIO_STREAM::cout << "FAILED" << METAIO_STREAM::endl;
+  else
+    METAIO_STREAM::cout << "PASSED" << METAIO_STREAM::endl;
+
+  sprintf(fName, "this/is/a/test");
+  METAIO_STREAM::cout << "MET_SetFileSuffix: 3:";
+  MET_SetFileSuffix(fName, "net");
+  if(strcmp(fName, "this/is/a/test.net"))
+    METAIO_STREAM::cout << "FAILED" << METAIO_STREAM::endl;
+  else
+    METAIO_STREAM::cout << "PASSED" << METAIO_STREAM::endl;
+
+  sprintf(fName, "this/is/a/test"); // Only necessary if previous test fails
+  METAIO_STREAM::cout << "MET_SetFileSuffix: 4:";
   MET_SetFileSuffix(fName, ".net");
   if(strcmp(fName, "this/is/a/test.net"))
     METAIO_STREAM::cout << "FAILED" << METAIO_STREAM::endl;


### PR DESCRIPTION
When adding a suffix to a file name in the MetaIO, the function
MET_SetFileSuffix is used. It checks if the file name already has
an extension, and in that case removes the extension. If it has an
extension, and the new extension starts with '.', it makes sure to
keep only one of the two '.'.
However, if the file name has no extension, and there no was check
to verify that the given extension started with '.'. This lead to
create file names without a '.' and with the file name concatenated
with the extension with no separator. This patch fixes this issue.