### PR TITLE
BUG: Inconsistency between MET_LONG_TYPE and MET_ULONG_TYPE

### DIFF
--- a/src/metaTypes.h
+++ b/src/metaTypes.h
@@ -39,7 +39,7 @@ typedef short               MET_SHORT_TYPE;
 typedef unsigned short      MET_USHORT_TYPE;
 typedef int                 MET_INT_TYPE;
 typedef unsigned int        MET_UINT_TYPE;
-typedef int                 MET_LONG_TYPE;
+typedef long                MET_LONG_TYPE;
 typedef unsigned long       MET_ULONG_TYPE;
 #if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MING_W32__)
 typedef __int64             MET_LONG_LONG_TYPE;


### PR DESCRIPTION
MET_LONG_TYPE was defined as 'int' but MET_ULONG_TYPE is defined
as 'unsigned long'. The two types should be consistent and be
defined based on the same type of variable.