### PR TITLE
ENH: Use integer types with fixed width

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,57 @@
-os:
-  - linux
 language: cpp
-compiler:
-  - gcc
-  - clang
+
+cache:
+  directories:
+  - ${ExternalData_OBJECT_STORES}
+
+env:
+  global:
+    - ExternalData_OBJECT_STORES="${HOME}/.ExternalData"
+    - PROJ_SRC="${TRAVIS_BUILD_DIR}"
+    - ITK_MODULE_NAME=MetaIO
+    - ITK_ADDITIONAL_MODULE_NAMES="ITKIOMeta"
+    - ITK_TAG=master
+    - ITK_SRC="${HOME}/ITK"
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      env: InsideITK=false
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+      env: InsideITK=false
+    - os: osx
+      osx_image: xcode7.3
+      env: InsideITK=false
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      env: InsideITK=true
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+      env: InsideITK=true
+    - os: osx
+      osx_image: xcode7.3
+      env: InsideITK=true
+
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja $( command -V cmake &>2 /dev/null || echo "cmake" ); fi
+
+before_script:
+  - cmake --version
+  - env
+  - if [[ $InsideITK = true ]]; then bash -x ${PROJ_SRC}/test/ci/CacheAndUpdateITK.sh; fi
+
 script:
-  - mkdir build
-  - cd build
-  - cmake ..
-  - cmake --build .
+  - if [[ $InsideITK = true ]]; then ctest -V -S ${PROJ_SRC}/test/ci/travis_dashboard.cmake; fi
+  - if [[ $InsideITK = false ]]; then mkdir build && cd build && cmake .. && cmake --build . ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ env:
     - ExternalData_OBJECT_STORES="${HOME}/.ExternalData"
     - PROJ_SRC="${TRAVIS_BUILD_DIR}"
     - ITK_MODULE_NAME=MetaIO
-    - ITK_ADDITIONAL_MODULE_NAMES="ITKIOMeta"
+    - ITK_BUILD_MODULES="ITKMetaIO;ITKIOMeta"
     - ITK_TAG=master
     - ITK_SRC="${HOME}/ITK"
+    - ITK_TEST_LABEL="ITKIOMeta"
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ environment:
     ITK_MODULE_NAME: MetaIO
     ITK_TAG: master
     ITK_SRC: 'C:\ITK'
+    ITK_TEST_LABEL: 'ITKIOMeta'
+    ITK_BUILD_MODULES: 'ITKMetaIO;ITKIOMeta'
 
   matrix:
     - GENERATOR: "Visual Studio 9 2008"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,14 +25,22 @@ environment:
 
   matrix:
     - GENERATOR: "Visual Studio 9 2008"
+      InsideITK: 0
+    - GENERATOR: "Visual Studio 9 2008"
+      InsideITK: 1
     - GENERATOR: "Visual Studio 14 2015 Win64"
+      InsideITK: 0
+    - GENERATOR: "Visual Studio 14 2015 Win64"
+      InsideITK: 1
+
 
 install:
-  - '%CYG_ROOT%/bin/bash -x "%PROJ_SRC%\test\ci\CacheAndUpdateITK.sh"'
-
+  - IF %InsideITK% EQU 1 (%CYG_ROOT%/bin/bash -x %APPVEYOR_BUILD_FOLDER%\test\ci\CacheAndUpdateITK.sh)
 build_script:
-  - ctest -V -C %configuration% -S "%APPVEYOR_BUILD_FOLDER%\\test\\ci\\appveyor_dashboard.cmake"
-
+  - >
+    IF %InsideITK% EQU 1 (ctest -V -C %configuration% -S "%APPVEYOR_BUILD_FOLDER%\\test\\ci\\appveyor_dashboard.cmake"
+    ) ELSE (mkdir build & cd build & cmake -G "%GENERATOR%" .. & cmake --build .)
+ 
 test: off
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+branches:
+ only:
+  - master
+  - /^ci.*$/
+
+platform:
+  - x86
+
+configuration:
+  - Release
+
+cache:
+  - '%USERPROFILE%\ExternalData'
+
+environment:
+  global:
+    CYG_ROOT: C:\cygwin
+    ExternalData_OBJECT_STORES: '%USERPROFILE%\ExternalData'
+    PROJ_SRC: '%APPVEYOR_BUILD_FOLDER%'
+    ITK_MODULE_NAME: MetaIO
+    ITK_TAG: master
+    ITK_SRC: 'C:\ITK'
+
+  matrix:
+    - GENERATOR: "Visual Studio 9 2008"
+    - GENERATOR: "Visual Studio 14 2015 Win64"
+
+install:
+  - '%CYG_ROOT%/bin/bash -x "%PROJ_SRC%\test\ci\CacheAndUpdateITK.sh"'
+
+build_script:
+  - ctest -V -C %configuration% -S "%APPVEYOR_BUILD_FOLDER%\\test\\ci\\appveyor_dashboard.cmake"
+
+test: off
+
+deploy: off

--- a/src/metaTypes.h
+++ b/src/metaTypes.h
@@ -10,6 +10,7 @@
   See the License for more information.
 ============================================================================*/
 #include "localMetaConfiguration.h"
+#include <stdint.h>
 
 #ifndef ITKMetaIO_METATYPES_H
 #define ITKMetaIO_METATYPES_H
@@ -33,20 +34,20 @@ namespace METAIO_NAMESPACE {
 #endif
 
 typedef char                MET_ASCII_CHAR_TYPE;
-typedef char                MET_CHAR_TYPE;
-typedef unsigned char       MET_UCHAR_TYPE;
-typedef short               MET_SHORT_TYPE;
-typedef unsigned short      MET_USHORT_TYPE;
-typedef int                 MET_INT_TYPE;
-typedef unsigned int        MET_UINT_TYPE;
-typedef long                MET_LONG_TYPE;
-typedef unsigned long       MET_ULONG_TYPE;
+typedef int8_t              MET_CHAR_TYPE;
+typedef uint8_t             MET_UCHAR_TYPE;
+typedef int16_t             MET_SHORT_TYPE;
+typedef uint16_t            MET_USHORT_TYPE;
+typedef int32_t             MET_INT_TYPE;
+typedef uint32_t            MET_UINT_TYPE;
+typedef int32_t             MET_LONG_TYPE;
+typedef uint32_t            MET_ULONG_TYPE;
 #if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MING_W32__)
 typedef __int64             MET_LONG_LONG_TYPE;
 typedef unsigned __int64    MET_ULONG_LONG_TYPE;
 #else
-typedef long long           MET_LONG_LONG_TYPE;
-typedef unsigned long long  MET_ULONG_LONG_TYPE;
+typedef int64_t             MET_LONG_LONG_TYPE;
+typedef uint64_t            MET_ULONG_LONG_TYPE;
 #endif
 typedef float               MET_FLOAT_TYPE;
 typedef double              MET_DOUBLE_TYPE;

--- a/src/metaTypes.h
+++ b/src/metaTypes.h
@@ -10,7 +10,9 @@
   See the License for more information.
 ============================================================================*/
 #include "localMetaConfiguration.h"
+#if !defined(_MSC_VER) || (_MSC_VER > 1500) // do not include this file for Visual Studio 2008
 #include <stdint.h>
+#endif
 
 #ifndef ITKMetaIO_METATYPES_H
 #define ITKMetaIO_METATYPES_H
@@ -31,6 +33,17 @@
  */
 #if (METAIO_USE_NAMESPACE)
 namespace METAIO_NAMESPACE {
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1500) // until Visual Studio 2008
+typedef signed __int8       int8_t;
+typedef signed __int16      int16_t;
+typedef signed __int32      int32_t;
+typedef unsigned __int8     uint8_t;
+typedef unsigned __int16    uint16_t;
+typedef unsigned __int32    uint32_t;
+typedef signed __int64      int64_t;
+typedef unsigned __int64    uint64_t;
 #endif
 
 typedef char                MET_ASCII_CHAR_TYPE;

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -315,7 +315,7 @@ bool MET_ValueToDouble(MET_ValueEnumType _type, const void *_data,
       *_value = (double)(((const MET_DOUBLE_TYPE *)_data)[_index]);
       return true;
     case MET_STRING:
-      *_value = atof(&(((const MET_CHAR_TYPE *)_data)[_index]));
+      *_value = atof(&(((const MET_ASCII_CHAR_TYPE *)_data)[_index]));
       return true;
     case MET_NONE:
     case MET_OTHER:
@@ -383,7 +383,7 @@ bool MET_DoubleToValue(double _value,
       ((MET_DOUBLE_TYPE *)_data)[_index] = (MET_DOUBLE_TYPE)_value;
       return true;
     case MET_STRING:
-      sprintf(&(((MET_CHAR_TYPE *)_data)[_index]), "%f", _value);
+      sprintf(&(((MET_ASCII_CHAR_TYPE *)_data)[_index]), "%f", _value);
       return true;
     case MET_NONE:
     case MET_OTHER:
@@ -465,7 +465,7 @@ bool MET_ValueToValue(MET_ValueEnumType _fromType, const void *_fromData,
       (((MET_FLOAT_TYPE *)_toData)[_index]) = (MET_FLOAT_TYPE)tf;
       return true;
     case MET_STRING:
-      sprintf(&(((MET_CHAR_TYPE *)_toData)[_index]), "%f", tf);
+      sprintf(&(((MET_ASCII_CHAR_TYPE *)_toData)[_index]), "%f", tf);
       return true;
     case MET_NONE:
     case MET_OTHER:
@@ -1153,7 +1153,8 @@ bool MET_Read(METAIO_STREAM::istream &fp,
               {
               break;
               }
-            MET_CHAR_TYPE * str = (MET_CHAR_TYPE *)((*fieldIter)->value);
+            MET_ASCII_CHAR_TYPE * str =
+                               (MET_ASCII_CHAR_TYPE *)((*fieldIter)->value);
             fp.getline( str, 500 );
             MET_StringStripEnd(str);
             (*fieldIter)->length = static_cast<int>( strlen( str ) );
@@ -1263,7 +1264,7 @@ bool MET_Read(METAIO_STREAM::istream &fp,
           }
         MET_FieldRecordType * mF = new MET_FieldRecordType;
         MET_InitReadField(mF, s, MET_STRING, false);
-        MET_CHAR_TYPE * str = (MET_CHAR_TYPE *)(mF->value);
+        MET_ASCII_CHAR_TYPE * str = (MET_ASCII_CHAR_TYPE *)(mF->value);
         fp.getline( str, 500 );
         MET_StringStripEnd(str);
         mF->length = static_cast<int>( strlen( str ) );
@@ -1671,7 +1672,8 @@ bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
         }
       break;
     case MET_STRING:
-      strcpy((MET_CHAR_TYPE *)(f.value), (const MET_CHAR_TYPE *)_v);
+      strcpy((MET_ASCII_CHAR_TYPE *)(f.value),
+             (const MET_ASCII_CHAR_TYPE *)_v);
       break;
     case MET_FLOAT_MATRIX:
       for(i=0; i<_n*_n; i++)

--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -278,7 +278,7 @@ MET_ValueEnumType MET_GetValueEnumType(const METAIO_STL::type_info & ptype)
     }
 
 inline
-void MET_StringStripEnd(MET_CHAR_TYPE * str)
+void MET_StringStripEnd(MET_ASCII_CHAR_TYPE * str)
     {
     // note the post-decrement in the condition
     for(size_t j = strlen(str); j-- > 0;)

--- a/test/ci/.gitattributes
+++ b/test/ci/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf

--- a/test/ci/CacheAndUpdateITK.sh
+++ b/test/ci/CacheAndUpdateITK.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+
+mkdir -p "${ExternalData_OBJECT_STORES}"
+
+echo "Using ITK repository: ${ITK_REPOSITORY_REMOTE:=https://github.com/InsightSoftwareConsortium/ITK.git}"
+
+if [ -n "${APPVEYOR_BUILD_FOLDER+x}" ]
+then
+    PROJ_SRC=${APPVEYOR_BUILD_FOLDER}
+fi
+
+
+git clone --single-branch ${ITK_REPOSITORY_REMOTE} -b "${ITK_TAG}" "${ITK_SRC}" &&
+ ( cd ${ITK_SRC}/Modules/Remote &&
+     ln -s ${PROJ_SRC} ${ITK_MODULE_NAME}
+ )
+
+( cd ${PROJ_SRC}/test &&
+    git clone --single-branch ${ITK_REPOSITORY_REMOTE} -b dashboard dashboard
+)
+
+( cd ${ITK_SRC}/Modules/ThirdParty/${ITK_MODULE_NAME}/ &&
+    UpdateFromUpstream.sh
+)

--- a/test/ci/CacheAndUpdateITK.sh
+++ b/test/ci/CacheAndUpdateITK.sh
@@ -9,16 +9,45 @@ then
     PROJ_SRC=${APPVEYOR_BUILD_FOLDER}
 fi
 
+snapshot_author_name='${ITK_MODULE_NAME} Maintainers'
+snapshot_author_email="${ITK_MODULE_NAME,,}@itk.org"
 
+snapshot_redact_cmd=''
+snapshot_relative_path='src/${ITK_MODULE_NAME}'
+snapshot_paths='
+  src
+  License.txt
+  '
+
+thirdparty_module_name="${ITK_MODULE_NAME}"
+upstream_git_url=${PROJ_SRC}
+upstream_git_branch='local_branch'
+
+( cd ${PROJ_SRC} &&
+     git checkout -b ${upstream_git_branch};
+     [ -f $(git rev-parse --git-dir)/shallow ] && git fetch --unshallow
+ )
+
+ # Hacking/overriding dirname to return the directory name
+ # expected by UpdateThirdPartyFromUpstream.sh
+ dirname()
+ {
+   echo ${ITK_SRC}/Modules/ThirdParty/${ITK_MODULE_NAME}
+ }
+ 
+ egrep()
+ {
+   grep -E $1
+ }
+ 
 git clone --single-branch ${ITK_REPOSITORY_REMOTE} -b "${ITK_TAG}" "${ITK_SRC}" &&
- ( cd ${ITK_SRC}/Modules/Remote &&
-     ln -s ${PROJ_SRC} ${ITK_MODULE_NAME}
+ (  cd ${ITK_SRC}/Modules/ThirdParty/${ITK_MODULE_NAME} &&
+    source "$(pwd)/../../../Utilities/Maintenance/UpdateThirdPartyFromUpstream.sh" &&
+    update_from_upstream &&
+    cd ${ITK_SRC} &&
+    git merge -X subtree=${ITK_SRC}/Modules/ThirdParty/${ITK_MODULE_NAME}/src/${ITK_MODULE_NAME} upstream-${ITK_MODULE_NAME,,} --strategy-option ours -m "Merge branch 'upstream-${ITK_MODULE_NAME,,}'"
  )
 
 ( cd ${PROJ_SRC}/test &&
     git clone --single-branch ${ITK_REPOSITORY_REMOTE} -b dashboard dashboard
-)
-
-( cd ${ITK_SRC}/Modules/ThirdParty/${ITK_MODULE_NAME}/ &&
-    UpdateFromUpstream.sh
 )

--- a/test/ci/CacheAndUpdateITK.sh
+++ b/test/ci/CacheAndUpdateITK.sh
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+echo ${ExternalData_OBJECT_STORES}
 mkdir -p "${ExternalData_OBJECT_STORES}"
 
 echo "Using ITK repository: ${ITK_REPOSITORY_REMOTE:=https://github.com/InsightSoftwareConsortium/ITK.git}"

--- a/test/ci/appveyor_dashboard.cmake
+++ b/test/ci/appveyor_dashboard.cmake
@@ -1,0 +1,26 @@
+# Client maintainer: blowekamp@mail.nih.gov
+set(CTEST_SITE "appveyor")
+set(CTEST_DASHBOARD_ROOT $ENV{APPVEYOR_BUILD_FOLDER}/..)
+string(SUBSTRING $ENV{APPVEYOR_REPO_COMMIT} 0 7 commit)
+
+# Extract major/minor/patch  versions
+
+set(what "$ENV{APPVEYOR_PULL_REQUEST_TITLE}_#$ENV{APPVEYOR_PULL_REQUEST_NUMBER}")
+if("$ENV{APPVEYOR_PULL_REQUEST_NUMBER}" STREQUAL "")
+  set(what "$ENV{APPVEYOR_REPO_BRANCH}")
+endif()
+set(CTEST_CONFIGURATION_TYPE $ENV{CONFIGURATION})
+set(CTEST_CMAKE_GENERATOR "$ENV{GENERATOR}")
+if("${CTEST_CMAKE_GENERATOR}" STREQUAL "")
+  set(CTEST_CMAKE_GENERATOR "Visual Studio 9 2008")
+endif()
+
+set(platform $ENV{PLATFORM})
+
+set(CTEST_BUILD_NAME "$ENV{ITK_MODULE_NAME}-VS-${platform}-$ENV{CONFIGURATION}_${what}_${commit}")
+
+list(APPEND CTEST_NOTES_FILES
+  "$ENV{PROJ_SRC}/appveyor.yml"
+  )
+
+include("${CTEST_SCRIPT_DIRECTORY}/common_dashboard.cmake")

--- a/test/ci/common_dashboard.cmake
+++ b/test/ci/common_dashboard.cmake
@@ -3,9 +3,11 @@
 #
 # Used environment variable:
 #  ITK_MODULE_NAME - name of the ITK external/remote module
+#  ITK_ADDITIONAL_MODULE_NAMES - names of other modules to compile
 #  ITK_SRC - ITK source directory ( already upto date )
 #  ITK_REPOSITORY - local or remote repository
 #  ITK_TAG - name of ITK tag or branch
+
 set(itk_module "$ENV{ITK_MODULE_NAME}")
 
 set(dashboard_no_update 0)
@@ -32,7 +34,11 @@ if(PROCESSOR_COUNT)
   endif()
   set( CTEST_TEST_ARGS ${CTEST_TEST_ARGS} PARALLEL_LEVEL ${PROCESSOR_COUNT} )
 endif()
-
+if(DEFINED ENV{ITK_ADDITIONAL_MODULE_NAMES})
+  foreach(var $ENV{ITK_ADDITIONAL_MODULE_NAMES})
+    set(itk_additional_modules ${itk_additional_modules} Module_${var}:BOOL=ON)
+  endforeach()
+endif()
 
 # this is the initial cache to use for the binary tree.
 SET (dashboard_cache "
@@ -45,7 +51,8 @@ SET (dashboard_cache "
 
     ITK_BUILD_DEFAULT_MODULES:BOOL=OFF
     ITKGroup_Core:BOOL=OFF
-    Module_${itk_module}:BOOL=ON
+    Module_ITK${itk_module}:BOOL=ON
+    ${itk_additional_modules}
 " )
 
 list(APPEND CTEST_NOTES_FILES

--- a/test/ci/common_dashboard.cmake
+++ b/test/ci/common_dashboard.cmake
@@ -1,0 +1,56 @@
+#
+# Example Dashboard script for CI services
+#
+# Used environment variable:
+#  ITK_MODULE_NAME - name of the ITK external/remote module
+#  ITK_SRC - ITK source directory ( already upto date )
+#  ITK_REPOSITORY - local or remote repository
+#  ITK_TAG - name of ITK tag or branch
+set(itk_module "$ENV{ITK_MODULE_NAME}")
+
+set(dashboard_no_update 0)
+if(DEFINED ENV{ITK_SRC})
+  set(CTEST_SOURCE_DIRECTORY "$ENV{ITK_SRC}")
+  set(dashboard_no_update 1)
+elseif(DEFINED ENV{ITK_REPOSITORY})
+  set(dashboard_git_url "$ENV{ITK_REPOSITORY}")
+  set(dashboard_git_branch "$ENV{ITK_TAG}")
+  set(CTEST_DASHBOARD_ROOT "$ENV{HOME}/dash")
+endif()
+
+set(CTEST_BUILD_TARGET "${itk_module}-all")
+set(CTEST_TEST_ARGS INCLUDE_LABEL ${itk_module})
+
+set(dashboard_model "Experimental")
+set(dashboard_track "Remote")
+
+include( ProcessorCount )
+ProcessorCount( PROCESSOR_COUNT )
+if(PROCESSOR_COUNT)
+  if (CTEST_CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+    set( CTEST_BUILD_FLAGS -j${PROCESSOR_COUNT})
+  endif()
+  set( CTEST_TEST_ARGS ${CTEST_TEST_ARGS} PARALLEL_LEVEL ${PROCESSOR_COUNT} )
+endif()
+
+
+# this is the initial cache to use for the binary tree.
+SET (dashboard_cache "
+
+    BUILD_DOCUMENTATION:BOOL=OFF
+    BUILD_EXAMPLES:BOOL=OFF
+    BUILD_SHARED_LIBS:BOOL=OFF
+    BUILD_TESTING:BOOL=ON
+    ITK_USE_KWSTYLE:BOOL=OFF
+
+    ITK_BUILD_DEFAULT_MODULES:BOOL=OFF
+    ITKGroup_Core:BOOL=OFF
+    Module_${itk_module}:BOOL=ON
+" )
+
+list(APPEND CTEST_NOTES_FILES
+  "${CMAKE_CURRENT_LIST_FILE}"
+  )
+
+include(${CTEST_SCRIPT_DIRECTORY}/../dashboard/itk_common.cmake)
+

--- a/test/ci/travis_dashboard.cmake
+++ b/test/ci/travis_dashboard.cmake
@@ -1,0 +1,21 @@
+# Client maintainer: blowekamp@mail.nih.gov
+execute_process(COMMAND hostname OUTPUT_VARIABLE hostname OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(CTEST_SITE "${hostname}")
+set(CTEST_DASHBOARD_ROOT $ENV{TRAVIS_BUILD_DIR}/..)
+get_filename_component(compiler_name $ENV{CC} NAME)
+string(SUBSTRING $ENV{TRAVIS_COMMIT} 0 7 commit)
+
+set(what "#$ENV{TRAVIS_PULL_REQUEST}")
+if($ENV{TRAVIS_PULL_REQUEST} STREQUAL "false")
+  set(what "$ENV{TRAVIS_BRANCH}")
+endif()
+set(CTEST_BUILD_NAME "$ENV{ITK_MODULE_NAME}-$ENV{TRAVIS_OS_NAME}-${compiler_name}_${what}_${commit}")
+
+set(CTEST_CONFIGURATION_TYPE Release)
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+list(APPEND CTEST_NOTES_FILES
+  "$ENV{PROJ_SRC}/.travis.yml"
+  )
+
+include("${CTEST_SCRIPT_DIRECTORY}/common_dashboard.cmake")

--- a/test/ci/travis_dashboard.cmake
+++ b/test/ci/travis_dashboard.cmake
@@ -11,7 +11,7 @@ if($ENV{TRAVIS_PULL_REQUEST} STREQUAL "false")
 endif()
 set(CTEST_BUILD_NAME "$ENV{ITK_MODULE_NAME}-$ENV{TRAVIS_OS_NAME}-${compiler_name}_${what}_${commit}")
 
-set(CTEST_CONFIGURATION_TYPE Release)
+set(CTEST_BUILD_CONFIGURATION Release)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 list(APPEND CTEST_NOTES_FILES


### PR DESCRIPTION
MetaIO already expects types to have a certain size [1]. (u)int and
(u)long are expected to be encoded on 4 bytes, (u)long long types
are expected to be encoded on 8 bytes. To avoid confusion due to
platform differences, we replace these types that are not visible
or used by the user by fixed width integer types, repectively
(u)int32_t for (u)int and (u)long and (u)unt64_t for (u)long long.
These types are defined in stdint.h

[1] https://github.com/Kitware/MetaIO/blob/master/src/metaTypes.h#L97