### PR TITLE
BUG: Remove static global c string used for storage of orientation

### DIFF
--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -830,14 +830,13 @@ DistanceUnits(const char * _distanceUnits)
 const char * MetaObject::
 AnatomicalOrientationAcronym(void) const
   {
-  static char str[10];
   int i;
   for(i=0; i<m_NDims; i++)
     {
-    str[i] = MET_OrientationTypeName[m_AnatomicalOrientation[i]][0];
+    m_OrientationAcronym[i] = MET_OrientationTypeName[m_AnatomicalOrientation[i]][0];
     }
-  str[i] = '\0';
-  return str;
+  m_OrientationAcronym[i] = '\0';
+  return m_OrientationAcronym;
   }
 
 const MET_OrientationEnumType * MetaObject::

--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -59,6 +59,7 @@ class METAIO_EXPORT MetaObject
       double m_CenterOfRotation[10];   // "CenterOfRotation = "  0 0 0
 
       MET_OrientationEnumType m_AnatomicalOrientation[10];
+      mutable char            m_OrientationAcronym[10];
 
       MET_DistanceUnitsEnumType m_DistanceUnits;   // "DistanceUnits = mm"
 


### PR DESCRIPTION
The static local variable can be shared between threads and may pose
an issue with concurrent access or initialization. The storage has
been made a mutable member variable to preserve the const accessors of
AnatomicalOrientationAcronym and yet still allow multiple instances of
metaObject to be used concurrently.