### PR TITLE
Fix (Un)Compression of files (and buffers) > 4GB

### DIFF
--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -1202,7 +1202,7 @@ M_SetupReadFields(void)
   m_Fields.push_back(mF);
 
   mF = new MET_FieldRecordType;
-  MET_InitReadField(mF, "CompressedDataSize", MET_FLOAT, false);
+  MET_InitReadField(mF, "CompressedDataSize", MET_ULONG_LONG, false);
   m_Fields.push_back(mF);
 
   mF = new MET_FieldRecordType;
@@ -1403,7 +1403,7 @@ M_SetupWriteFields(void)
       if(m_WriteCompressedDataSize && m_CompressedDataSize>0)
         {
         mF = new MET_FieldRecordType;
-        MET_InitWriteField(mF, "CompressedDataSize", MET_UINT,
+        MET_InitWriteField(mF, "CompressedDataSize", MET_ULONG_LONG,
                            static_cast<double>(m_CompressedDataSize));
         m_Fields.push_back(mF);
         }
@@ -1577,7 +1577,7 @@ M_Read(void)
   mF = MET_GetFieldRecord("CompressedDataSize",  &m_Fields);
   if(mF && mF->defined)
     {
-    m_CompressedDataSize = (unsigned int)mF->value[0];
+    m_CompressedDataSize = (unsigned long long)mF->value[0];
     }
 
   mF = MET_GetFieldRecord("BinaryData",  &m_Fields);

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -1368,12 +1368,12 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
         }
       case MET_ULONG_LONG:
         { // ToDo: check why name was not printed here previously!
-          fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
+        fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
 #if defined(_MSC_VER) || defined(__HP_aCC)
         // NOTE: you cannot use __int64 in an ostream in MSV6 or HPUX
-          fp << convert_ulonglong_to_string((MET_ULONG_LONG_TYPE)((*fieldIter)->value[0])) << METAIO_STREAM::endl;
+        fp << convert_ulonglong_to_string((MET_ULONG_LONG_TYPE)((*fieldIter)->value[0])) << METAIO_STREAM::endl;
 #else
-          fp << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
+        fp << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
 #endif
         break;
         }

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -788,7 +788,7 @@ bool MET_PerformUncompression(const unsigned char * sourceCompressed,
       if (err == Z_STREAM_END || err < 0)
         {
         if (err != Z_STREAM_END &&
-            err != Z_BUF_ERROR) // Sometimes inflate returns this non fatal.
+            err != Z_BUF_ERROR) // inflate returns this when there is still data to uncompress, but no space left in buffer; non-fatal
           {
           METAIO_STREAM::cerr << "Uncompress failed" << METAIO_STREAM::endl;
           }

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -28,7 +28,7 @@ inline bool IsBlank(int c)
 
 #include "metaUtils.h"
 
-#include <cassert>
+//#include <cassert>
 #include <stdio.h>
 #include <ctype.h>
 #include <stddef.h>
@@ -711,7 +711,7 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
   unsigned char * compressed_data   = new unsigned char[buffer_out_size];
 
   int ret = deflateInit(&z, compression_rate);
-  assert(ret == Z_OK);
+  //assert(ret == Z_OK);
 
   METAIO_STL::streamoff cur_in_start = 0;
   METAIO_STL::streamoff cur_out_start = 0;
@@ -728,7 +728,7 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
       z.avail_out = chunk_size;
       z.next_out  = output_buffer;
       ret = deflate(&z, flush);
-      assert(ret != Z_STREAM_ERROR);
+      //assert(ret != Z_STREAM_ERROR);
       METAIO_STL::streamoff count_out = chunk_size - z.avail_out;
       if ( (cur_out_start + count_out) >= buffer_out_size )
         {
@@ -744,10 +744,10 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
       cur_out_start += count_out;
       }
     while (z.avail_out == 0);
-    assert(z.avail_in == 0);
+    //assert(z.avail_in == 0);
     }
   while (flush != Z_FINISH);
-  assert(ret == Z_STREAM_END);
+  //assert(ret == Z_STREAM_END);
   delete [] output_buffer;
   *compressedDataSize = cur_out_start;  // don't use z.total_out, it's limited to 2^32!
   deflateEnd(&z);

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -1366,8 +1366,7 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
         // NOTE: you cannot use __int64 in an ostream in MSV6 or HPUX
           fp << convert_ulonglong_to_string((MET_ULONG_LONG_TYPE)((*fieldIter)->value[0])) << METAIO_STREAM::endl;
 #else
-          fp << (*fieldIter)->name << " " << MET_SeperatorChar << " "
-             << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
+          fp << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
 #endif
         break;
         }

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -799,7 +799,7 @@ bool MET_PerformUncompression(const unsigned char * sourceCompressed,
       }
     while (d_stream.avail_out == 0);
     }
-  while (true);
+  while (err != Z_STREAM_END && err >= 0);
   inflateEnd(&d_stream);
   return true;
   }


### PR DESCRIPTION
This fixes writing compressed image files > 4GB, as well as reading such files.
There were two major issues:
* The `MET_PerformCompression` function passed an overflow-truncated version of the actual available bytes to deflate; so actually only the first (ActualByteSize % UINT_MAX) bytes were ever pased into zlib. I've rewritten the loop to pass in chunks of (currently up to) 4GB until all available bytes have been processed by deflate; the behavior of the `MET_PerformUncompression` function was very similar.
* In writing the CompressedDataSize, the element was assumed to be of type MET_UINT. This caused the value to be truncated as well to  (ActualByteSize % UINT_MAX). Not sure if my fix of setting the value to MET_ULONG_LONG and fixing the writing of those values is proper, there's two potential issues that I'd need more input on:
  1. The value is anyway converted to double for the field initialization, I guess this could cause the value to get imprecise?
  2. Previously, for MET_ULONG_LONG values, the "Name = " prefix was omitted, was this on purpose because such values have a special meaning, or was this actually a bug?

I have tested the written files to be readable properly with [Fiji](https://fiji.sc/). With my second commit, also reading those compressed files now works properly here.