### PR TITLE
ENH: Run ITK tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: insighttoolkit/metaio-test:latest
+     steps:
+       - checkout:
+          path: /usr/src/MetaIO
+       - run: /usr/src/MetaIO/test/ci/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,6 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       env: InsideITK=false
-    - os: linux
-      dist: trusty
-      sudo: required
-      compiler: gcc
-      env: InsideITK=true
-    - os: linux
-      dist: trusty
-      sudo: required
-      compiler: clang
-      env: InsideITK=true
     - os: osx
       osx_image: xcode7.3
       env: InsideITK=true

--- a/test/ci/Dockerfile
+++ b/test/ci/Dockerfile
@@ -1,0 +1,46 @@
+FROM debian:9
+MAINTAINER Insight Software Consortium <community@itk.org>
+
+RUN REPO=http://cdn-fastly.deb.debian.org && \
+  echo "deb $REPO/debian stretch main\ndeb $REPO/debian stretch-updates main\ndeb $REPO/debian-security stretch/updates main" > /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  cmake \
+  git \
+  libexpat1-dev \
+  libhdf5-dev \
+  libjpeg-dev \
+  libpng-dev \
+  libtiff5-dev \
+  python \
+  ninja-build \
+  zlib1g-dev \
+  && apt-get clean
+
+RUN mkdir -p /usr/src/MetaIO-build
+WORKDIR /usr/src
+
+# ITK master 2017-07-18
+ENV ITK_GIT_TAG 72e9386064c583701a35502f661c94d9f4d5884a
+RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git && \
+  cd ITK && \
+  git checkout ${ITK_GIT_TAG} && \
+  cd ../ && \
+  mkdir ITK-build && \
+  cd ITK-build && \
+  cmake \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+    -DCMAKE_BUILD_TYPE:STRING=MinSizeRel \
+    -DBUILD_EXAMPLES:BOOL=OFF \
+    -DBUILD_TESTING:BOOL=ON \
+    -DBUILD_SHARED_LIBS:BOOL=ON \
+    -DITK_LEGACY_REMOVE:BOOL=ON \
+    -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF \
+    -DITKGroup_Core:BOOL=OFF \
+    -DITK_USE_SYSTEM_LIBRARIES:BOOL=ON \
+    -DModule_ITKIOMeta:BOOL=ON \
+  ../ITK && \
+  ninja && \
+  find . -name '*.o' -delete

--- a/test/ci/build.sh
+++ b/test/ci/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker build -t insighttoolkit/metaio-test $script_dir

--- a/test/ci/run.sh
+++ b/test/ci/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker run \
+  --rm \
+  -v $script_dir/../..:/usr/src/MetaIO \
+    insighttoolkit/metaio-test \
+      /usr/src/MetaIO/test/ci/test.sh

--- a/test/ci/test.sh
+++ b/test/ci/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This is a script to build the modules and run the test suite in the base
+# Docker container.
+
+set -x
+set -o
+
+cd /usr/src/MetaIO
+branch=$(git rev-parse --abbrev-ref HEAD)
+date=$(date +%F_%H_%M_%S)
+sha=$(git rev-parse --short HEAD)
+
+cd /usr/src/ITK
+# Dummy values required to make git commits in the update script
+git config user.name ci-testing
+git config user.email ci@testing
+./Modules/ThirdParty/MetaIO/UpdateFromUpstream.sh /usr/src/MetaIO $branch
+cd /usr/src/ITK-build
+cmake \
+  -DBUILDNAME:STRING=External-MetaIO-${branch}-${date}-${sha} \
+    .
+ninja
+ctest -VV -D Experimental -L ITKIOMeta


### PR DESCRIPTION
Create a Docker image with the testing environment. This image can be built by
calling test/ci/build.sh. To test merging this repository into ITK,
re-building ITK, and running ITK's MetaIO tests, call test/ci/run.sh.