### PR TITLE
BUG: Address fatal error when merging MetaIO changes into ITK in CI

### DIFF
--- a/test/ci/CacheAndUpdateITK.sh
+++ b/test/ci/CacheAndUpdateITK.sh
@@ -5,6 +5,10 @@ mkdir -p "${ExternalData_OBJECT_STORES}"
 
 echo "Using ITK repository: ${ITK_REPOSITORY_REMOTE:=https://github.com/InsightSoftwareConsortium/ITK.git}"
 
+
+git config --global user.email "testing@appveyor.com"
+git config --global user.name "MetaIO CI"
+
 if [ -n "${APPVEYOR_BUILD_FOLDER+x}" ]
 then
     PROJ_SRC=${APPVEYOR_BUILD_FOLDER}


### PR DESCRIPTION
This should address the following error on Appveyor:
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.