### PR TITLE
c++11: use `override` where possible

### DIFF
--- a/src/metaArray.h
+++ b/src/metaArray.h
@@ -76,13 +76,13 @@ class METAIO_EXPORT MetaArray : public MetaForm
               bool _allocateElementData=false,
               bool _autoFreeElementData=false);
 
-    ~MetaArray(void);
+    ~MetaArray(void) MET_OVERRIDE;
 
-    void  PrintInfo(void) const;
+    void  PrintInfo(void) const MET_OVERRIDE;
 
-    void  CopyInfo(const MetaForm * _form);
+    void  CopyInfo(const MetaForm * _form) MET_OVERRIDE;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     bool  InitializeEssential(int _nDims,
                               MET_ValueEnumType _elementType,
@@ -188,13 +188,13 @@ class METAIO_EXPORT MetaArray : public MetaForm
 
     void *             m_ElementData;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
     bool  M_ReadElements(METAIO_STREAM::ifstream * _fstream,
                          void * _data,

--- a/src/metaArrow.h
+++ b/src/metaArrow.h
@@ -61,13 +61,13 @@ class METAIO_EXPORT MetaArrow : public MetaObject
 
     MetaArrow(unsigned int dim);
 
-    ~MetaArrow(void);
+    ~MetaArrow(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     void  Length(float length);
     float Length(void) const;
@@ -86,13 +86,13 @@ class METAIO_EXPORT MetaArrow : public MetaObject
   ////
   protected:
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
     float M_Length; // default 1.0
 

--- a/src/metaBlob.h
+++ b/src/metaBlob.h
@@ -81,11 +81,11 @@ class METAIO_EXPORT MetaBlob : public MetaObject
 
     MetaBlob(unsigned int dim);
 
-    ~MetaBlob(void);
+    ~MetaBlob(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -100,7 +100,7 @@ class METAIO_EXPORT MetaBlob : public MetaObject
     const char* PointDim(void) const;
 
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType & GetPoints(void) {return m_PointList;}
     const PointListType & GetPoints(void) const  {return m_PointList;}
@@ -117,15 +117,15 @@ class METAIO_EXPORT MetaBlob : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     size_t  m_NPoints;      // "NPoints = "         0
 

--- a/src/metaContour.h
+++ b/src/metaContour.h
@@ -94,10 +94,10 @@ public:
  MetaContour(const MetaContour *_Contour);
  MetaContour(unsigned int dim);
 
- ~MetaContour(void);
+ ~MetaContour(void) MET_OVERRIDE;
 
-  void PrintInfo(void) const;
-  void CopyInfo(const MetaObject * _object);
+  void PrintInfo(void) const MET_OVERRIDE;
+  void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
   //    NPoints(...)
   //       Required Field
@@ -127,7 +127,7 @@ public:
   void DisplayOrientation(int display);
   int  DisplayOrientation() const;
 
-  void  Clear(void);
+  void  Clear(void) MET_OVERRIDE;
 
   ControlPointListType & GetControlPoints(void)
     {return m_ControlPointsList;}
@@ -142,11 +142,11 @@ public:
 protected:
 
   bool  m_ElementByteOrderMSB;
-  void  M_Destroy(void);
-  void  M_SetupReadFields(void);
-  void  M_SetupWriteFields(void);
-  bool  M_Read(void);
-  bool  M_Write(void);
+  void  M_Destroy(void) MET_OVERRIDE;
+  void  M_SetupReadFields(void) MET_OVERRIDE;
+  void  M_SetupWriteFields(void) MET_OVERRIDE;
+  bool  M_Read(void) MET_OVERRIDE;
+  bool  M_Write(void) MET_OVERRIDE;
 
   int m_NControlPoints;
   int m_NInterpolatedPoints;

--- a/src/metaDTITube.h
+++ b/src/metaDTITube.h
@@ -94,11 +94,11 @@ class METAIO_EXPORT MetaDTITube : public MetaObject
 
     MetaDTITube(unsigned int dim);
 
-    ~MetaDTITube(void);
+    ~MetaDTITube(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -125,7 +125,7 @@ class METAIO_EXPORT MetaDTITube : public MetaObject
     void  ParentPoint(int parentpoint);
     int   ParentPoint(void) const;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType &  GetPoints(void) {return m_PointList;}
     const PointListType &  GetPoints(void) const {return m_PointList;}
@@ -142,15 +142,15 @@ class METAIO_EXPORT MetaDTITube : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int m_ParentPoint;  // "ParentPoint = "     -1
 

--- a/src/metaEllipse.h
+++ b/src/metaEllipse.h
@@ -62,13 +62,13 @@ class METAIO_EXPORT MetaEllipse : public MetaObject
 
     MetaEllipse(unsigned int dim);
 
-    ~MetaEllipse(void);
+    ~MetaEllipse(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     void  Radius(const float* radius);
     void  Radius(float radius);
@@ -84,13 +84,13 @@ class METAIO_EXPORT MetaEllipse : public MetaObject
   ////
   protected:
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
     float m_Radius[100];  // "Radius = "     0
 

--- a/src/metaFEMObject.h
+++ b/src/metaFEMObject.h
@@ -211,14 +211,14 @@ public:
 
   MetaFEMObject(unsigned int dim);
 
-  ~MetaFEMObject(void);
+  ~MetaFEMObject(void) MET_OVERRIDE;
 
-  void PrintInfo(void) const;
+  void PrintInfo(void) const MET_OVERRIDE;
 
-  void CopyInfo(const MetaObject * _object);
+  void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
   /** Clear the MetaFEMObject */
-  void  Clear(void);
+  void  Clear(void) MET_OVERRIDE;
 
   /** List of valid class name types from FEM namespace*/
   typedef METAIO_STL::list<std::string> ClassNameListType;
@@ -244,15 +244,15 @@ public:
 
 protected:
 
-  void  M_Destroy(void);
+  void  M_Destroy(void) MET_OVERRIDE;
 
-  void  M_SetupReadFields(void);
+  void  M_SetupReadFields(void) MET_OVERRIDE;
 
-  void  M_SetupWriteFields(void);
+  void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-  bool  M_Read(void);
+  bool  M_Read(void) MET_OVERRIDE;
 
-  bool  M_Write(void);
+  bool  M_Write(void) MET_OVERRIDE;
 
   /** For reading and writing in node details */
   bool  M_Read_Node();

--- a/src/metaGaussian.h
+++ b/src/metaGaussian.h
@@ -61,13 +61,13 @@ class METAIO_EXPORT MetaGaussian : public MetaObject
 
     MetaGaussian(unsigned int dim);
 
-    ~MetaGaussian(void);
+    ~MetaGaussian(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     /** Set/Get the maximum value. */
     void Maximum(float val) { m_Maximum = val; }
@@ -88,16 +88,16 @@ class METAIO_EXPORT MetaGaussian : public MetaObject
   ////
   protected:
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
     /** Set up the fields to read a MetaGaussian file. */
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
     /** Set up the fields to write a MetaGaussian file. */
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
     /** Read the MetaGaussian file properties. */
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
     /** The maximum value of the MetaGaussian object. */
     float m_Maximum;

--- a/src/metaGroup.h
+++ b/src/metaGroup.h
@@ -61,13 +61,13 @@ class METAIO_EXPORT MetaGroup : public MetaObject
 
     MetaGroup(unsigned int dim);
 
-    ~MetaGroup(void);
+    ~MetaGroup(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
 
   ////
@@ -77,13 +77,13 @@ class METAIO_EXPORT MetaGroup : public MetaObject
   ////
   protected:
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
   };
 

--- a/src/metaImage.h
+++ b/src/metaImage.h
@@ -97,13 +97,13 @@ class METAIO_EXPORT MetaImage : public MetaObject
               int _elementNumberOfChannels=1,
               void *_elementData=NULL);
 
-    ~MetaImage(void);
+    ~MetaImage(void) MET_OVERRIDE;
 
-    virtual void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    virtual void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
-    virtual void Clear(void);
+    void Clear(void) MET_OVERRIDE;
 
     bool InitializeEssential(int _nDims,
                                      const int * _dimSize,
@@ -281,7 +281,7 @@ class METAIO_EXPORT MetaImage : public MetaObject
                              const void * _constElementData=NULL);
 
 
-    bool Append(const char *_headName=NULL);
+    bool Append(const char *_headName=NULL) MET_OVERRIDE;
 
 
     typedef METAIO_STL::pair<long,long> CompressionOffsetType;
@@ -327,13 +327,13 @@ class METAIO_EXPORT MetaImage : public MetaObject
     char               m_ElementDataFileName[255];
 
 
-    virtual void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    virtual void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    virtual void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    virtual bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
     // _dataQuantity is expressed in number of pixels. Internally it will be
     // scaled by the number of components and number of bytes per component.

--- a/src/metaLandmark.h
+++ b/src/metaLandmark.h
@@ -81,11 +81,11 @@ class METAIO_EXPORT MetaLandmark : public MetaObject
 
     MetaLandmark(unsigned int dim);
 
-    ~MetaLandmark(void);
+    ~MetaLandmark(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -100,7 +100,7 @@ class METAIO_EXPORT MetaLandmark : public MetaObject
     const char* PointDim(void) const;
 
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType & GetPoints(void) {return m_PointList;}
     const PointListType & GetPoints(void) const  {return m_PointList;}
@@ -117,15 +117,15 @@ class METAIO_EXPORT MetaLandmark : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int   m_NPoints;      // "NPoints = "         0
 

--- a/src/metaLine.h
+++ b/src/metaLine.h
@@ -80,11 +80,11 @@ class METAIO_EXPORT MetaLine : public MetaObject
 
     MetaLine(unsigned int dim);
 
-    ~MetaLine(void);
+    ~MetaLine(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
 
     //    NPoints(...)
@@ -100,7 +100,7 @@ class METAIO_EXPORT MetaLine : public MetaObject
     const char* PointDim(void) const;
 
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType & GetPoints(void) {return m_PointList;}
     const PointListType & GetPoints(void) const {return m_PointList;}
@@ -117,15 +117,15 @@ class METAIO_EXPORT MetaLine : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int   m_NPoints;      // "NPoints = "         0
 

--- a/src/metaMesh.h
+++ b/src/metaMesh.h
@@ -143,14 +143,14 @@ class METAIO_EXPORT MeshData : public MeshDataBase
 public:
 
   MeshData() {m_Id=-1;}
-  ~MeshData() {}
+  ~MeshData() MET_OVERRIDE {}
 
-  virtual MET_ValueEnumType GetMetaType()
+  MET_ValueEnumType GetMetaType() MET_OVERRIDE
     {
     return MET_GetPixelType(typeid(TElementType));
     }
 
-  virtual void Write( METAIO_STREAM::ofstream* stream)
+  void Write( METAIO_STREAM::ofstream* stream) MET_OVERRIDE
     {
     //char* id = new char[sizeof(int)];
     // The file is written as LSB by default
@@ -167,7 +167,7 @@ public:
     stream->write((char *)&data,sizeof(data));
     }
 
-  virtual unsigned int GetSize(void)
+  unsigned int GetSize(void) MET_OVERRIDE
     {
     unsigned int size = sizeof(int);
     size += sizeof(m_Data);
@@ -207,11 +207,11 @@ class METAIO_EXPORT MetaMesh : public MetaObject
 
     MetaMesh(unsigned int dim);
 
-    ~MetaMesh(void);
+    ~MetaMesh(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -235,7 +235,7 @@ class METAIO_EXPORT MetaMesh : public MetaObject
     int   NCellTypes(void) const;
 
     /** Clear the metaMesh */
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType & GetPoints(void) {return m_PointList;}
     const PointListType & GetPoints(void) const  {return m_PointList;}
@@ -267,15 +267,15 @@ class METAIO_EXPORT MetaMesh : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int m_NPoints;
     int m_NCells;

--- a/src/metaOutput.h
+++ b/src/metaOutput.h
@@ -70,10 +70,10 @@ class MetaFileOutputStream : public MetaOutputStream
   public:
 
     MetaFileOutputStream(const char* name);
-    virtual ~MetaFileOutputStream() {}
+    ~MetaFileOutputStream() MET_OVERRIDE {}
 
-    bool Open();
-    bool Close();
+    bool Open() MET_OVERRIDE;
+    bool Close() MET_OVERRIDE;
 
     METAIO_STL::string GetFileName();
 

--- a/src/metaScene.h
+++ b/src/metaScene.h
@@ -62,11 +62,11 @@ class METAIO_EXPORT MetaScene : public MetaObject
 
     MetaScene(unsigned int dim);
 
-    ~MetaScene(void);
+    ~MetaScene(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     void AddObject(MetaObject* object);
 
@@ -78,9 +78,9 @@ class METAIO_EXPORT MetaScene : public MetaObject
 
     bool Write(const char *_headName=NULL);
 
-    bool Append(const char* =NULL) {METAIO_STREAM::cout << "Not Implemented !" << METAIO_STREAM::endl;return true;}
+    bool Append(const char* =NULL) MET_OVERRIDE {METAIO_STREAM::cout << "Not Implemented !" << METAIO_STREAM::endl;return true;}
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
 
     //    NObjects(...)
@@ -101,15 +101,15 @@ class METAIO_EXPORT MetaScene : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int m_NObjects;      // "NObjects = "         0
 

--- a/src/metaSurface.h
+++ b/src/metaSurface.h
@@ -79,11 +79,11 @@ class METAIO_EXPORT MetaSurface : public MetaObject
 
     MetaSurface(unsigned int dim);
 
-    ~MetaSurface(void);
+    ~MetaSurface(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -98,7 +98,7 @@ class METAIO_EXPORT MetaSurface : public MetaObject
     const char* PointDim(void) const;
 
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType & GetPoints(void) {return m_PointList;}
     const PointListType & GetPoints(void) const {return m_PointList;}
@@ -115,15 +115,15 @@ class METAIO_EXPORT MetaSurface : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int m_NPoints;      // "NPoints = "         0
 

--- a/src/metaTransform.h
+++ b/src/metaTransform.h
@@ -62,13 +62,13 @@ class METAIO_EXPORT MetaTransform : public MetaObject
 
     MetaTransform(unsigned int dim);
 
-    ~MetaTransform(void);
+    ~MetaTransform(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     // Set/Get the parameters of the transforms
     const double * Parameters(void) const;
@@ -102,14 +102,14 @@ class METAIO_EXPORT MetaTransform : public MetaObject
   ////
   protected:
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
-    bool  M_Write(void);
+    bool  M_Read(void) MET_OVERRIDE;
+    bool  M_Write(void) MET_OVERRIDE;
 
     double* parameters;
     unsigned int parametersDimension;

--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -81,11 +81,11 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     MetaTube(unsigned int dim);
 
-    virtual ~MetaTube(void);
+    ~MetaTube(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -112,7 +112,7 @@ class METAIO_EXPORT MetaTube : public MetaObject
     void  ParentPoint(int parentpoint);
     int   ParentPoint(void) const;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType &  GetPoints(void) {return m_PointList;}
     const PointListType &  GetPoints(void) const {return m_PointList;}
@@ -129,15 +129,15 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int m_ParentPoint;  // "ParentPoint = "     -1
 

--- a/src/metaTubeGraph.h
+++ b/src/metaTubeGraph.h
@@ -90,11 +90,11 @@ class METAIO_EXPORT MetaTubeGraph : public MetaObject
 
     MetaTubeGraph(unsigned int dim);
 
-    ~MetaTubeGraph(void);
+    ~MetaTubeGraph(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -115,7 +115,7 @@ class METAIO_EXPORT MetaTubeGraph : public MetaObject
     int   Root(void) const;
 
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType &  GetPoints(void) {return m_PointList;}
     const PointListType &  GetPoints(void) const {return m_PointList;}
@@ -130,15 +130,15 @@ class METAIO_EXPORT MetaTubeGraph : public MetaObject
   ////
   protected:
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int m_Root;         // "Root = "            0
 

--- a/src/metaTypes.h
+++ b/src/metaTypes.h
@@ -219,6 +219,12 @@ typedef struct
                                   //   meta data
    } MET_FieldRecordType;
 
+#if __cplusplus >= 201103L
+#define MET_OVERRIDE override
+#else
+#define MET_OVERRIDE
+#endif
+
 #if (METAIO_USE_NAMESPACE)
 };
 #endif

--- a/src/metaVesselTube.h
+++ b/src/metaVesselTube.h
@@ -89,11 +89,11 @@ class METAIO_EXPORT MetaVesselTube : public MetaObject
 
     MetaVesselTube(unsigned int dim);
 
-    ~MetaVesselTube(void);
+    ~MetaVesselTube(void) MET_OVERRIDE;
 
-    void PrintInfo(void) const;
+    void PrintInfo(void) const MET_OVERRIDE;
 
-    void CopyInfo(const MetaObject * _object);
+    void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     //    NPoints(...)
     //       Required Field
@@ -126,7 +126,7 @@ class METAIO_EXPORT MetaVesselTube : public MetaObject
     void  ParentPoint(int parentpoint);
     int   ParentPoint(void) const;
 
-    void  Clear(void);
+    void  Clear(void) MET_OVERRIDE;
 
     PointListType &  GetPoints(void) {return m_PointList;}
     const PointListType &  GetPoints(void) const {return m_PointList;}
@@ -143,15 +143,15 @@ class METAIO_EXPORT MetaVesselTube : public MetaObject
 
     bool  m_ElementByteOrderMSB;
 
-    void  M_Destroy(void);
+    void  M_Destroy(void) MET_OVERRIDE;
 
-    void  M_SetupReadFields(void);
+    void  M_SetupReadFields(void) MET_OVERRIDE;
 
-    void  M_SetupWriteFields(void);
+    void  M_SetupWriteFields(void) MET_OVERRIDE;
 
-    bool  M_Read(void);
+    bool  M_Read(void) MET_OVERRIDE;
 
-    bool  M_Write(void);
+    bool  M_Write(void) MET_OVERRIDE;
 
     int   m_ParentPoint;  // "ParentPoint = "     -1
 


### PR DESCRIPTION
Though non-C++11 compilers still need to be supported, so use the
keyword through a macro instead.

Fixes #36.