### PR TITLE
BUG: Change the default precision for printing double value

### DIFF
--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -159,7 +159,7 @@ MetaImage(MetaImage *_im)
 MetaImage::
 MetaImage(int _nDims,
           const int * _dimSize,
-          const float * _elementSpacing,
+          const double * _elementSpacing,
           MET_ValueEnumType _elementType,
           int _elementNumberOfChannels,
           void *_elementData)
@@ -199,7 +199,7 @@ MetaImage(int _nDims,
 //
 MetaImage::
 MetaImage(int _x, int _y,
-          float _elementSpacingX, float _elementSpacingY,
+          double _elementSpacingX, double _elementSpacingY,
           MET_ValueEnumType _elementType,
           int _elementNumberOfChannels, void *_elementData)
 :MetaObject()
@@ -218,7 +218,7 @@ MetaImage(int _x, int _y,
   ds[0] = _x;
   ds[1] = _y;
 
-  float es[2];
+  double es[2];
   es[0] = _elementSpacingX;
   es[1] = _elementSpacingY;
 
@@ -247,9 +247,9 @@ MetaImage(int _x, int _y,
 //
 MetaImage::
 MetaImage(int _x, int _y, int _z,
-          float _elementSpacingX,
-          float _elementSpacingY,
-          float _elementSpacingZ,
+          double _elementSpacingX,
+          double _elementSpacingY,
+          double _elementSpacingZ,
           MET_ValueEnumType _elementType,
           int _elementNumberOfChannels,
           void *_elementData)
@@ -270,7 +270,7 @@ MetaImage(int _x, int _y, int _z,
   ds[1] = _y;
   ds[2] = _z;
 
-  float es[3];
+  double es[3];
   es[0] = _elementSpacingX;
   es[1] = _elementSpacingY;
   es[2] = _elementSpacingZ;
@@ -449,10 +449,10 @@ void MetaImage::Clear(void)
 
   m_HeaderSize = 0;
 
-  memset(m_SequenceID, 0, 4*sizeof(float));
+  memset(m_SequenceID, 0, sizeof(m_SequenceID));
 
   m_ElementSizeValid = false;
-  memset(m_ElementSize, 0, 10*sizeof(float));
+  memset(m_ElementSize, 0, sizeof(m_ElementSize));
 
   m_ElementType = MET_NONE;
 
@@ -499,7 +499,7 @@ void MetaImage::Clear(void)
 bool MetaImage::
 InitializeEssential(int _nDims,
                     const int * _dimSize,
-                    const float * _elementSpacing,
+                    const double * _elementSpacing,
                     MET_ValueEnumType _elementType,
                     int _elementNumberOfChannels,
                     void * _elementData,
@@ -683,27 +683,27 @@ ElementSizeValid(bool _elementSizeValid)
   m_ElementSizeValid = _elementSizeValid;
   }
 
-const float * MetaImage::
+const double * MetaImage::
 ElementSize(void) const
   {
   return m_ElementSize;
   }
 
-float MetaImage::
+double MetaImage::
 ElementSize(int _i) const
   {
   return m_ElementSize[_i];
   }
 
 void MetaImage::
-ElementSize(const float *_elementSize)
+ElementSize(const double *_elementSize)
   {
-  memcpy(m_ElementSize, _elementSize, m_NDims*sizeof(float));
+  memcpy(m_ElementSize, _elementSize, m_NDims*sizeof(*m_ElementSize));
   m_ElementSizeValid = true;
   }
 
 void MetaImage::
-ElementSize(int _i, float _value)
+ElementSize(int _i, double _value)
   {
   m_ElementSize[_i] = _value;
   m_ElementSizeValid = true;
@@ -2421,7 +2421,7 @@ M_Read(void)
     int i;
     for(i=0; i<m_NDims; i++)
       {
-      m_ElementSize[i] = (float)(mF->value[i]);
+      m_ElementSize[i] = mF->value[i];
       }
     mF = MET_GetFieldRecord("ElementSpacing", &m_Fields);
     if(mF && !mF->defined)

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -159,6 +159,47 @@ MetaImage(MetaImage *_im)
 MetaImage::
 MetaImage(int _nDims,
           const int * _dimSize,
+          const float * _elementSpacing,
+          MET_ValueEnumType _elementType,
+          int _elementNumberOfChannels,
+          void *_elementData)
+:MetaObject()
+  {
+  if(META_DEBUG)
+    {
+    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    }
+
+  m_CompressionTable = new MET_CompressionTableType;
+  m_CompressionTable->buffer = NULL;
+  m_CompressionTable->compressedStream = NULL;
+  Clear();
+
+  if(_elementData == NULL)
+    {
+    InitializeEssential(_nDims,
+                        _dimSize,
+                        _elementSpacing,
+                        _elementType,
+                        _elementNumberOfChannels,
+                        NULL, true);
+    }
+  else
+    {
+    InitializeEssential(_nDims,
+                        _dimSize,
+                        _elementSpacing,
+                        _elementType,
+                        _elementNumberOfChannels,
+                        _elementData, false);
+    }
+
+  }
+
+//
+MetaImage::
+MetaImage(int _nDims,
+          const int * _dimSize,
           const double * _elementSpacing,
           MET_ValueEnumType _elementType,
           int _elementNumberOfChannels,
@@ -499,6 +540,27 @@ void MetaImage::Clear(void)
 bool MetaImage::
 InitializeEssential(int _nDims,
                     const int * _dimSize,
+                    const float * _elementSpacing,
+                    MET_ValueEnumType _elementType,
+                    int _elementNumberOfChannels,
+                    void * _elementData,
+                    bool _allocElementMemory)
+{
+  // Only consider at most 10 element of spacing:
+  // See MetaObject::InitializeEssential(_nDims)
+  double tmpElementSpacing[10];
+  int ndims = std::max( std::min( _nDims, 10 ), 0);
+  for( int i = 0; i < ndims; ++i )
+    {
+    tmpElementSpacing[i] = static_cast<double>(_elementSpacing[i]);
+    }
+  return InitializeEssential(_nDims, _dimSize, tmpElementSpacing, _elementType,
+    _elementNumberOfChannels, _elementData, _allocElementMemory);
+}
+
+bool MetaImage::
+InitializeEssential(int _nDims,
+                    const int * _dimSize,
                     const double * _elementSpacing,
                     MET_ValueEnumType _elementType,
                     int _elementNumberOfChannels,
@@ -701,6 +763,17 @@ ElementSize(const double *_elementSize)
   memcpy(m_ElementSize, _elementSize, m_NDims*sizeof(*m_ElementSize));
   m_ElementSizeValid = true;
   }
+
+void MetaImage::
+ElementSize(const float *_elementSize)
+  {
+  for(int i = 0; i < m_NDims; ++i)
+    {
+    m_ElementSize[i] = static_cast<double>(_elementSize[i]);
+    }
+  m_ElementSizeValid = true;
+  }
+
 
 void MetaImage::
 ElementSize(int _i, double _value)

--- a/src/metaImage.h
+++ b/src/metaImage.h
@@ -77,6 +77,13 @@ class METAIO_EXPORT MetaImage : public MetaObject
 
     MetaImage(int _nDims,
               const int * _dimSize,
+              const float *_elementSpacing,
+              MET_ValueEnumType _elementType,
+              int _elementNumberOfChannels=1,
+              void *_elementData=NULL);
+
+    MetaImage(int _nDims,
+              const int * _dimSize,
               const double *_elementSpacing,
               MET_ValueEnumType _elementType,
               int _elementNumberOfChannels=1,
@@ -104,6 +111,15 @@ class METAIO_EXPORT MetaImage : public MetaObject
     void CopyInfo(const MetaObject * _object) MET_OVERRIDE;
 
     void Clear(void) MET_OVERRIDE;
+
+    // Legacy for floating point elementSpacing
+    bool InitializeEssential(int _nDims,
+                                     const int * _dimSize,
+                                     const float * _elementSpacing,
+                                     MET_ValueEnumType _elementType,
+                                     int _elementNumberOfChannels=1,
+                                     void *_elementData=NULL,
+                                     bool _allocElementMemory=true);
 
     bool InitializeEssential(int _nDims,
                                      const int * _dimSize,
@@ -160,6 +176,7 @@ class METAIO_EXPORT MetaImage : public MetaObject
     const double *  ElementSize(void) const;
     double          ElementSize(int i) const;
     void            ElementSize(const double * _pointSize);
+    void            ElementSize(const float * _pointSize); // legacy
     void            ElementSize(int _i, double _value);
 
     MET_ValueEnumType ElementType(void) const;

--- a/src/metaImage.h
+++ b/src/metaImage.h
@@ -77,22 +77,22 @@ class METAIO_EXPORT MetaImage : public MetaObject
 
     MetaImage(int _nDims,
               const int * _dimSize,
-              const float *_elementSpacing,
+              const double *_elementSpacing,
               MET_ValueEnumType _elementType,
               int _elementNumberOfChannels=1,
               void *_elementData=NULL);
 
     MetaImage(int _x, int _y,
-              float _elementSpacingX,
-              float _elementSpacingY,
+              double _elementSpacingX,
+              double _elementSpacingY,
               MET_ValueEnumType _elementType,
               int _elementNumberOfChannels=1,
               void *_elementData=NULL);
 
     MetaImage(int _x, int _y, int _z,
-              float _elementSpacingX,
-              float _elementSpacingY,
-              float _elementSpacingZ,
+              double _elementSpacingX,
+              double _elementSpacingY,
+              double _elementSpacingZ,
               MET_ValueEnumType _elementType,
               int _elementNumberOfChannels=1,
               void *_elementData=NULL);
@@ -107,7 +107,7 @@ class METAIO_EXPORT MetaImage : public MetaObject
 
     bool InitializeEssential(int _nDims,
                                      const int * _dimSize,
-                                     const float * _elementSpacing,
+                                     const double * _elementSpacing,
                                      MET_ValueEnumType _elementType,
                                      int _elementNumberOfChannels=1,
                                      void *_elementData=NULL,
@@ -155,12 +155,12 @@ class METAIO_EXPORT MetaImage : public MetaObject
     //       Optional Field
     //       Physical size (in MM) of each element in the image
     //       (0 = xSize, 1 = ySize, 2 = zSize)
-    bool           ElementSizeValid(void) const;
-    void           ElementSizeValid(bool _elementSizeValid);
-    const float *  ElementSize(void) const;
-    float          ElementSize(int i) const;
-    void           ElementSize(const float * _pointSize);
-    void           ElementSize(int _i, float _value);
+    bool            ElementSizeValid(void) const;
+    void            ElementSizeValid(bool _elementSizeValid);
+    const double *  ElementSize(void) const;
+    double          ElementSize(int i) const;
+    void            ElementSize(const double * _pointSize);
+    void            ElementSize(int _i, double _value);
 
     MET_ValueEnumType ElementType(void) const;
     void              ElementType(MET_ValueEnumType _elementType);
@@ -307,7 +307,7 @@ class METAIO_EXPORT MetaImage : public MetaObject
     float              m_SequenceID[4];
 
     bool               m_ElementSizeValid;
-    float              m_ElementSize[10];
+    double             m_ElementSize[10];
 
     MET_ValueEnumType  m_ElementType;
 

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -932,6 +932,16 @@ ElementSpacing(const double * _elementSpacing)
   }
 
 void MetaObject::
+ElementSpacing(const float * _elementSpacing)
+  {
+  int i;
+  for(i=0; i<m_NDims; i++)
+    {
+    m_ElementSpacing[i] = static_cast<double>(_elementSpacing[i]);
+    }
+  }
+
+void MetaObject::
 ElementSpacing(int _i, double _value)
   {
   m_ElementSpacing[_i] = _value;

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -1060,10 +1060,10 @@ Clear(void)
   strcpy(m_ObjectSubTypeName, "");
   strcpy(m_Name, "");
 
-  memset(m_Offset, 0, 10*sizeof(float));
-  memset(m_TransformMatrix, 0, 100*sizeof(float));
-  memset(m_CenterOfRotation, 0, 10*sizeof(float));
-  memset(m_Color, 0, 4*sizeof(float));
+  memset(m_Offset, 0, sizeof(m_Offset));
+  memset(m_TransformMatrix, 0, sizeof(m_TransformMatrix));
+  memset(m_CenterOfRotation, 0, sizeof(m_CenterOfRotation));
+  memset(m_Color, 0, sizeof(m_Color));
 
   m_ID = -1;
   m_Color[0]=1.0f;

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -909,20 +909,20 @@ AnatomicalOrientation(int _dim, char _ao)
 
 //
 //
-const float * MetaObject::
+const double * MetaObject::
 ElementSpacing(void) const
   {
   return m_ElementSpacing;
   }
 
-float MetaObject::
+double MetaObject::
 ElementSpacing(int _i) const
   {
   return m_ElementSpacing[_i];
   }
 
 void MetaObject::
-ElementSpacing(const float * _elementSpacing)
+ElementSpacing(const double * _elementSpacing)
   {
   int i;
   for(i=0; i<m_NDims; i++)
@@ -932,7 +932,7 @@ ElementSpacing(const float * _elementSpacing)
   }
 
 void MetaObject::
-ElementSpacing(int _i, float _value)
+ElementSpacing(int _i, double _value)
   {
   m_ElementSpacing[_i] = _value;
   }
@@ -1744,7 +1744,7 @@ M_Read(void)
       {
       for(i=0; i<mF->length && i < 10; i++)
         {
-        m_ElementSpacing[i] = static_cast<float>( mF->value[i] );
+        m_ElementSpacing[i] = mF->value[i];
         if (META_DEBUG)
           {
           METAIO_STREAM::cout << "metaObject: M_Read: elementSpacing["

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -24,6 +24,9 @@
 namespace METAIO_NAMESPACE {
 #endif
 
+// Do not enforce c++11 requirement here, prefer storing the result of
+// std::numeric_limits<double>::max_digits10:
+#define MAX_DIGITS10 17
 
 //
 // MetaObject Constructors
@@ -40,7 +43,7 @@ MetaObject(void)
   m_WriteStream = NULL;
   m_FileName[0] = '\0';
   m_Event = NULL;
-  m_DoublePrecision = 6;
+  m_DoublePrecision = MAX_DIGITS10;
   m_DistanceUnits = MET_DISTANCE_UNITS_UNKNOWN;
   }
 
@@ -56,7 +59,7 @@ MetaObject(const char * _fileName)
   m_WriteStream = NULL;
   this->Read(_fileName);
   m_Event = NULL;
-  m_DoublePrecision = 6;
+  m_DoublePrecision = MAX_DIGITS10;
   m_DistanceUnits = MET_DISTANCE_UNITS_UNKNOWN;
   }
 
@@ -73,7 +76,7 @@ MetaObject(unsigned int dim)
   m_FileName[0] = '\0';
   InitializeEssential(dim);
   m_Event = NULL;
-  m_DoublePrecision = 6;
+  m_DoublePrecision = MAX_DIGITS10;
   m_DistanceUnits = MET_DISTANCE_UNITS_UNKNOWN;
   }
 

--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -221,6 +221,7 @@ class METAIO_EXPORT MetaObject
       const double * ElementSpacing(void) const;
       double ElementSpacing(int _i) const;
       void  ElementSpacing(const double * _elementSpacing);
+      void  ElementSpacing(const float * _elementSpacing);
       void  ElementSpacing(int _i, double _value);
 
       //    Name(...)

--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -63,7 +63,7 @@ class METAIO_EXPORT MetaObject
 
       MET_DistanceUnitsEnumType m_DistanceUnits;   // "DistanceUnits = mm"
 
-      float m_ElementSpacing[10];   // "ElementSpacing = "   0,0,0
+      double m_ElementSpacing[10];   // "ElementSpacing = "   0,0,0
 
       float m_Color[4];             // "Color = "            1.0, 0.0, 0.0, 1.0
 
@@ -218,10 +218,10 @@ class METAIO_EXPORT MetaObject
       //    ElementSpacing(...)
       //       Optional Field
       //       Physical Spacing (in same units as position)
-      const float * ElementSpacing(void) const;
-      float ElementSpacing(int _i) const;
-      void  ElementSpacing(const float * _elementSpacing);
-      void  ElementSpacing(int _i, float _value);
+      const double * ElementSpacing(void) const;
+      double ElementSpacing(int _i) const;
+      void  ElementSpacing(const double * _elementSpacing);
+      void  ElementSpacing(int _i, double _value);
 
       //    Name(...)
       //       Optional Field


### PR DESCRIPTION
The conversion of a floating-point to text and back is exact as long as
at least `max_digits10` is used (17 for double).

The net effect is that the text representation is now closer to the
DICOM Image Orientation (Patient) or Image Position (Patient) attribute
and will allow easier conversion from one representation to the other.