### PR TITLE
BUG: Change the default precision for printing double value

### DIFF
--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -24,6 +24,9 @@
 namespace METAIO_NAMESPACE {
 #endif
 
+// Do not enforce c++11 requirement here, prefer storing the result of
+// std::numeric_limits<double>::max_digits10:
+#define METAIO_MAX_DIGITS10 17
 
 //
 // MetaObject Constructors
@@ -40,7 +43,7 @@ MetaObject(void)
   m_WriteStream = NULL;
   m_FileName[0] = '\0';
   m_Event = NULL;
-  m_DoublePrecision = 6;
+  m_DoublePrecision = METAIO_MAX_DIGITS10;
   m_DistanceUnits = MET_DISTANCE_UNITS_UNKNOWN;
   }
 
@@ -56,7 +59,7 @@ MetaObject(const char * _fileName)
   m_WriteStream = NULL;
   this->Read(_fileName);
   m_Event = NULL;
-  m_DoublePrecision = 6;
+  m_DoublePrecision = METAIO_MAX_DIGITS10;
   m_DistanceUnits = MET_DISTANCE_UNITS_UNKNOWN;
   }
 
@@ -73,7 +76,7 @@ MetaObject(unsigned int dim)
   m_FileName[0] = '\0';
   InitializeEssential(dim);
   m_Event = NULL;
-  m_DoublePrecision = 6;
+  m_DoublePrecision = METAIO_MAX_DIGITS10;
   m_DistanceUnits = MET_DISTANCE_UNITS_UNKNOWN;
   }
 


### PR DESCRIPTION
The conversion of a floating-point to text and back is exact as long as
at least `max_digits10` is used (17 for double).

The net effect is that the text representation is now closer to the
DICOM Image Orientation (Patient) or Image Position (Patient) attribute
and will allow easier conversion from one representation to the other.

Since commit InsightSoftwareConsortium/ITK@e532c682930f ITK explicitly set the default precision to 6,
change of default will be transparent.