### PR TITLE
cmake: fix a typo for VTK's module system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,7 @@ if (METAIO_FOR_VTK)
   vtk_module_add_module(vtkmetaio
     SOURCES ${sources}
     HEADERS ${headers}
-    HEADER_SUBDIR "vtkmetaio")
+    HEADERS_SUBDIR "vtkmetaio")
 else ()
   add_library(${METAIO_NAMESPACE}
     ${sources}


### PR DESCRIPTION
---
Typo when transcribing into metaio master from VTK.