### PR TITLE
ENH: Bump ITK version in CircleCI / Docker build

### DIFF
--- a/test/ci/Dockerfile
+++ b/test/ci/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir -p /usr/src/MetaIO-build
 WORKDIR /usr/src
 
-# ITK master 2017-07-18
-ENV ITK_GIT_TAG 72e9386064c583701a35502f661c94d9f4d5884a
+# ITK master 2018-01-09
+ENV ITK_GIT_TAG 57ccc63e4a42c464e26ed1554c5ae7fc14d7d14d
 RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git && \
   cd ITK && \
   git checkout ${ITK_GIT_TAG} && \


### PR DESCRIPTION
This includes an update to the image baseline to account for MetaIO precision
increases in Kitware/MetaIO@62b654327a9ee5590eb3b503e2bb4f0de0904b68

CC: @cquammen @malaterre @jcfr @fbudin69500  