### PR TITLE
Increasing buffer sizes to avoid warnings coming from usage of sprintf

### DIFF
--- a/src/metaArray.cxx
+++ b/src/metaArray.cxx
@@ -736,7 +736,7 @@ ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements,
 
   bool usePath;
   char pathName[255];
-  char fName[255];
+  char fName[1024];
   usePath = MET_GetFilePath(m_FileName, pathName);
 
   if(_readElements)
@@ -1207,7 +1207,7 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data,
     localData = false;
     tmpWriteStream = new METAIO_STREAM::ofstream;
 
-    char dataFileName[255];
+    char dataFileName[1024];
     char pathName[255];
     bool usePath = MET_GetFilePath(m_FileName, pathName);
     if(usePath)

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -1381,7 +1381,7 @@ ReadStream(int _nDims,
     size_t j;
     bool usePath;
     char pathName[MAXPATHLENGTH];
-    char fName[MAXPATHLENGTH];
+    char fName[2*MAXPATHLENGTH+1];
     usePath = MET_GetFilePath(m_FileName, pathName);
 
     if(!strcmp("Local", m_ElementDataFileName) ||
@@ -2048,7 +2048,7 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
 
       dataPos = 0;
 
-      char dataFileName[MAXPATHLENGTH];
+      char dataFileName[MAXPATHLENGTH+256];
       if(usePath&& !FileIsFullPath(m_ElementDataFileName))
         {
         sprintf(dataFileName, "%s%s", pathName, m_ElementDataFileName);
@@ -2640,7 +2640,7 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream,
     }
   else // write the data in a separate file
     {
-    char dataFileName[MAXPATHLENGTH];
+    char dataFileName[MAXPATHLENGTH+256];
     char pathName[MAXPATHLENGTH];
     bool usePath = MET_GetFilePath(m_FileName, pathName);
     if(usePath&& !FileIsFullPath(m_ElementDataFileName))
@@ -2875,7 +2875,7 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
 
     bool usePath;
     char pathName[MAXPATHLENGTH];
-    char fName[MAXPATHLENGTH];
+    char fName[2*MAXPATHLENGTH+1];
     usePath = MET_GetFilePath(m_FileName, pathName);
 
     if(!strcmp("Local", m_ElementDataFileName) ||


### PR DESCRIPTION
Example message:

/home/kitware/dashboards/buildbot/vtk_master-eeloo-linux-shared-release_mpi_nogl/source/Utilities/MetaIO/vtkmetaio/metaImage.cxx: In member function 'bool vtkmetaio::MetaImage::M_WriteElements(std::ofstream*, const void*, std::streamoff)':
/home/kitware/dashboards/buildbot/vtk_master-eeloo-linux-shared-release_mpi_nogl/source/Utilities/MetaIO/vtkmetaio/metaImage.cxx:2580:29: warning: '%s' directive writing up to 254 bytes into a region of size between 1 and 2048 [-Wformat-overflow=]
       sprintf(dataFileName, "%s%s", pathName, m_ElementDataFileName);
                             ^~~~~~
/home/kitware/dashboards/buildbot/vtk_master-eeloo-linux-shared-release_mpi_nogl/source/Utilities/MetaIO/vtkmetaio/metaImage.cxx:2580:14: note: 'sprintf' output between 1 and 2302 bytes into a destination of size 2048
       sprintf(dataFileName, "%s%s", pathName, m_ElementDataFileName);
       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~