### PR TITLE
Fixed some cppcheck warnings

### DIFF
--- a/src/metaArray.cxx
+++ b/src/metaArray.cxx
@@ -772,10 +772,7 @@ ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements,
         m_ReadStream = NULL;
         return false;
         }
-      if(_readElements)
-        {
-        M_ReadElements(readStreamTemp, m_ElementData, m_Length);
-        }
+      M_ReadElements(readStreamTemp, m_ElementData, m_Length);
       readStreamTemp->close();
       delete readStreamTemp;
       }

--- a/src/metaArrow.cxx
+++ b/src/metaArrow.cxx
@@ -94,7 +94,7 @@ CopyInfo(const MetaObject * _object)
     const MetaArrow * arrow;
     try
       {
-      arrow = (const MetaArrow *)(_object);
+      arrow = static_cast<const MetaArrow *>(_object);
       }
     catch( ... )
       {

--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -63,7 +63,7 @@ ExtractDateFromCVS(METAIO_STL::string date)
     {
     newdate += date[i];
     }
-  return newdate.c_str();
+  return newdate;
 }
 
 void MetaCommand::DisableDeprecatedWarnings()
@@ -86,7 +86,7 @@ ExtractVersionFromCVS(METAIO_STL::string version)
     {
     newversion += version[i];
     }
-  return newversion.c_str();
+  return newversion;
 }
 
 void MetaCommand::
@@ -1098,6 +1098,8 @@ ParseXML(const char* buffer)
   while(buf.size() > 0)
     {
     Option option;
+    option.userDefined = false;
+    option.complete = false;
     option.name = this->GetXML(buf.c_str(),"name",0);
     option.tag = this->GetXML(buf.c_str(),"tag",0);
     option.longtag = this->GetXML(buf.c_str(),"longtag",0);

--- a/src/metaDTITube.cxx
+++ b/src/metaDTITube.cxx
@@ -556,8 +556,6 @@ M_Read(void)
         m_Event->SetCurrentIteration(j+1);
         }
 
-      DTITubePnt* pnt = new DTITubePnt(m_NDims);
-
       for(int k=0; k<pntDim; k++)
         {
         *m_ReadStream >> v[k];
@@ -571,13 +569,16 @@ M_Read(void)
       if( positionOfX < 0 )
         {
         METAIO_STREAM::cerr << "MetaDTITube: M_Read: 'x' not found." << METAIO_STREAM::endl;
+        return false;
         }
 
       if( positionOfY < 0 )
         {
         METAIO_STREAM::cerr << "MetaDTITube: M_Read: 'y' not found." << METAIO_STREAM::endl;
+        return false;
         }
 
+      DTITubePnt* pnt = new DTITubePnt(m_NDims);
       pnt->m_X[0] = v[positionOfX];
       pnt->m_X[1] = v[positionOfY];
 
@@ -588,6 +589,8 @@ M_Read(void)
         if( positionOfZ < 0 )
           {
           METAIO_STREAM::cerr << "MetaDTITube: M_Read: 'z' not found." << METAIO_STREAM::endl;
+          delete pnt;
+          return false;
           }
 
         pnt->m_X[2] = v[positionOfZ];

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -435,7 +435,7 @@ CopyInfo(const MetaObject * _object)
     const MetaImage * im;
     try
       {
-      im = (const MetaImage *)(_object);
+      im = static_cast<const MetaImage *>(_object);
       }
     catch( ... )
       {


### PR DESCRIPTION
- removed a redundant null check
- C to C++ style casts
- remove unnecessary c_str() calls
- return early instead of underflowing an array
- set uninitialized fields of a struct