### PR TITLE
COMP: Add missing headers for installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,14 +82,36 @@ set(sources
   )
 
 set(headers
-  metaTypes.h
+  localMetaConfiguration.h
+  metaArray.h
+  metaArrow.h
+  metaBlob.h
   metaCommand.h
   metaContour.h
-  metaMesh.h
-  metaOutput.h
-  metaForm.h
-  metaArray.h
+  metaDTITube.h
+  metaEllipse.h
+  metaEvent.h
   metaFEMObject.h
+  metaForm.h
+  metaGaussian.h
+  metaGroup.h
+  metaImage.h
+  metaImageTypes.h
+  metaImageUtils.h
+  metaITKUtils.h
+  metaLandmark.h
+  metaLine.h
+  metaMesh.h
+  metaObject.h
+  metaOutput.h
+  metaScene.h
+  metaSurface.h
+  metaTransform.h
+  metaTubeGraph.h
+  metaTube.h
+  metaTypes.h
+  metaUtils.h
+  metaVesselTube.h
   "${CMAKE_CURRENT_BINARY_DIR}/metaIOConfig.h"
 )
 


### PR DESCRIPTION
To address:

  https://github.com/InsightSoftwareConsortium/ITK/issues/619

from regression introduced in:

  https://github.com/Kitware/MetaIO/commit/81e134c37dd789000a0cbbed63b65fbdc82013f3