### PR TITLE
STYLE: remove METAIO_STL and METAIO_STREAM macros

### DIFF
--- a/src/localMetaConfiguration.h
+++ b/src/localMetaConfiguration.h
@@ -15,12 +15,6 @@
 #ifdef METAIO_NAMESPACE
   #undef METAIO_NAMESPACE
 #endif
-#ifdef METAIO_STL
-  #undef METAIO_STL
-#endif
-#ifdef METAIO_STREAM
-  #undef METAIO_STREAM
-#endif
 #ifdef METAIO_EXPORT
   #undef METAIO_EXPORT
 #endif
@@ -35,8 +29,6 @@
 
   #include "itk_zlib.h"
 
-  #define METAIO_STL    std
-  #define METAIO_STREAM std
   #include <iostream>
   #include <fstream>
 
@@ -50,8 +42,6 @@
 
   #include "vtk_zlib.h"
 
-  #define METAIO_STL    std
-  #define METAIO_STREAM std
   #include <iostream>
   #include <fstream>
 

--- a/src/metaArray.cxx
+++ b/src/metaArray.cxx
@@ -36,7 +36,7 @@ MetaArray()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray()" << METAIO_STREAM::endl;
+    std::cout << "MetaArray()" << std::endl;
     }
 
   m_ElementData = nullptr;
@@ -56,7 +56,7 @@ MetaArray(const char *_headerName)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray()" << METAIO_STREAM::endl;
+    std::cout << "MetaArray()" << std::endl;
     }
 
   m_ElementData = nullptr;
@@ -80,7 +80,7 @@ MetaArray(MetaArray *_vector,
   {
   if(META_DEBUG)
    {
-   METAIO_STREAM::cout << "MetaArray()" << METAIO_STREAM::endl;
+   std::cout << "MetaArray()" << std::endl;
    }
 
   m_ElementData = nullptr;
@@ -114,7 +114,7 @@ MetaArray(int _length,
   {
   if(META_DEBUG)
    {
-   METAIO_STREAM::cout << "MetaArray()" << METAIO_STREAM::endl;
+   std::cout << "MetaArray()" << std::endl;
    }
 
   m_ElementData = nullptr;
@@ -147,38 +147,38 @@ PrintInfo() const
   {
   MetaForm::PrintInfo();
 
-  METAIO_STREAM::cout << "Length = " << (int)m_Length << METAIO_STREAM::endl;
+  std::cout << "Length = " << (int)m_Length << std::endl;
 
-  METAIO_STREAM::cout << "BinaryData = "
+  std::cout << "BinaryData = "
                       << ((m_BinaryData)?"True":"False")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "BinaryDataByteOrderMSB = "
+  std::cout << "BinaryDataByteOrderMSB = "
                       << ((m_BinaryDataByteOrderMSB)?"True":"False")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 
-  METAIO_STREAM::cout << "ElementNumberOfChannels = "
+  std::cout << "ElementNumberOfChannels = "
                       << m_ElementNumberOfChannels
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "AutoFreeElementData = "
+  std::cout << "AutoFreeElementData = "
                       << ((m_AutoFreeElementData)?"True":"False")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "CompressedElementDataSize = "
+  std::cout << "CompressedElementDataSize = "
                       << m_CompressedElementDataSize
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "ElementDataFileName = " << m_ElementDataFileName
-                      << METAIO_STREAM::endl;
+  std::cout << "ElementDataFileName = " << m_ElementDataFileName
+                      << std::endl;
 
-  METAIO_STREAM::cout << "ElementData = "
+  std::cout << "ElementData = "
                       << ((m_ElementData==nullptr)?"NULL":"Valid")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
   }
 
 void MetaArray::
@@ -192,7 +192,7 @@ Clear()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaArray: Clear" << std::endl;
     }
 
   m_Length = 0;
@@ -228,7 +228,7 @@ InitializeEssential(int _length,
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: Initialize" << METAIO_STREAM::endl;
+    std::cout << "MetaArray: Initialize" << std::endl;
     }
 
   MetaForm::InitializeEssential();
@@ -366,8 +366,8 @@ ElementByteOrderSwap()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: ElementByteOrderSwap"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: ElementByteOrderSwap"
+                        << std::endl;
     }
 
   int eSize;
@@ -593,7 +593,7 @@ bool MetaArray::
 CanRead(const char *_headerName) const
   {
   // First check the extension
-  METAIO_STL::string fname = _headerName;
+  std::string fname = _headerName;
   if( fname == "" )
     {
     return false;
@@ -601,15 +601,15 @@ CanRead(const char *_headerName) const
 
   bool extensionFound = false;
 
-  METAIO_STL::string::size_type stringPos = fname.rfind(".mva");
-  if ((stringPos != METAIO_STL::string::npos)
+  std::string::size_type stringPos = fname.rfind(".mva");
+  if ((stringPos != std::string::npos)
       && (stringPos == fname.length() - 4))
     {
     extensionFound = true;
     }
 
   stringPos = fname.rfind(".mvh");
-  if ((stringPos != METAIO_STL::string::npos)
+  if ((stringPos != std::string::npos)
       && (stringPos == fname.length() - 4))
     {
     extensionFound = true;
@@ -621,13 +621,13 @@ CanRead(const char *_headerName) const
     }
 
   // Now check the file content
-  METAIO_STREAM::ifstream inputStream;
+  std::ifstream inputStream;
 
 #ifdef __sgi
-  inputStream.open( _headerName, METAIO_STREAM::ios::in );
+  inputStream.open( _headerName, std::ios::in );
 #else
-  inputStream.open( _headerName, METAIO_STREAM::ios::in |
-                                 METAIO_STREAM::ios::binary );
+  inputStream.open( _headerName, std::ios::in |
+                                 std::ios::binary );
 #endif
 
   if( !inputStream.rdbuf()->is_open() )
@@ -652,19 +652,19 @@ Read(const char *_headerName, bool _readElements,
     strcpy(m_FileName, _headerName);
     }
 
-  METAIO_STREAM::ifstream * tmpStream = new METAIO_STREAM::ifstream;
+  std::ifstream * tmpStream = new std::ifstream;
 
 #ifdef __sgi
-  tmpStream->open(m_FileName, METAIO_STREAM::ios::in );
+  tmpStream->open(m_FileName, std::ios::in );
 #else
-  tmpStream->open(m_FileName, METAIO_STREAM::ios::in |
-                              METAIO_STREAM::ios::binary);
+  tmpStream->open(m_FileName, std::ios::in |
+                              std::ios::binary);
 #endif
 
   if(!tmpStream->rdbuf()->is_open())
     {
-    METAIO_STREAM::cout << "MetaArray: Read: Cannot open file _"
-                        << m_FileName << "_" << METAIO_STREAM::endl;
+    std::cout << "MetaArray: Read: Cannot open file _"
+                        << m_FileName << "_" << std::endl;
     delete tmpStream;
     return false;
     }
@@ -686,7 +686,7 @@ Read(const char *_headerName, bool _readElements,
 
 
 bool MetaArray::
-CanReadStream(METAIO_STREAM::ifstream * _stream) const
+CanReadStream(std::ifstream * _stream) const
   {
   if(!strncmp(MET_ReadForm(*_stream).c_str(), "Array", 5))
     {
@@ -696,12 +696,12 @@ CanReadStream(METAIO_STREAM::ifstream * _stream) const
   }
 
 bool MetaArray::
-ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements,
+ReadStream(std::ifstream * _stream, bool _readElements,
            void * _elementDataBuffer, bool _autoFreeElementData)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: ReadStream" << METAIO_STREAM::endl;
+    std::cout << "MetaArray: ReadStream" << std::endl;
     }
 
   M_Destroy();
@@ -712,8 +712,8 @@ ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements,
 
   if(m_ReadStream)
     {
-    METAIO_STREAM::cout << "MetaArray: ReadStream: two files open?"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: ReadStream: two files open?"
+                        << std::endl;
     delete m_ReadStream;
     }
 
@@ -721,8 +721,8 @@ ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements,
 
   if(!M_Read())
     {
-    METAIO_STREAM::cout << "MetaArray: Read: Cannot parse file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: Read: Cannot parse file"
+                        << std::endl;
     m_ReadStream = nullptr;
     return false;
     }
@@ -757,18 +757,18 @@ ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements,
         {
         strcpy(fName, m_ElementDataFileName);
         }
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
 
 #ifdef __sgi
-      readStreamTemp->open(fName, METAIO_STREAM::ios::in);
+      readStreamTemp->open(fName, std::ios::in);
 #else
-      readStreamTemp->open(fName, METAIO_STREAM::ios::binary |
-                                  METAIO_STREAM::ios::in);
+      readStreamTemp->open(fName, std::ios::binary |
+                                  std::ios::in);
 #endif
       if(!readStreamTemp->rdbuf()->is_open())
         {
-        METAIO_STREAM::cout << "MetaArray: Read: Cannot open data file"
-                            << METAIO_STREAM::endl;
+        std::cout << "MetaArray: Read: Cannot open data file"
+                            << std::endl;
         m_ReadStream = nullptr;
         return false;
         }
@@ -850,19 +850,19 @@ Write(const char *_headName, const char *_dataName, bool _writeElements,
       }
     }
 
-  METAIO_STREAM::ofstream * tmpWriteStream = new METAIO_STREAM::ofstream;
+  std::ofstream * tmpWriteStream = new std::ofstream;
 
 // Some older sgi compilers have a error in the ofstream constructor
 // that requires a file to exist for output
 #ifdef __sgi
   {
-  METAIO_STREAM::ofstream tFile(m_FileName, METAIO_STREAM::ios::out);
+  std::ofstream tFile(m_FileName, std::ios::out);
   tFile.close();
   }
-  tmpWriteStream->open(m_FileName, METAIO_STREAM::ios::out);
+  tmpWriteStream->open(m_FileName, std::ios::out);
 #else
-  tmpWriteStream->open(m_FileName, METAIO_STREAM::ios::binary |
-                                   METAIO_STREAM::ios::out);
+  tmpWriteStream->open(m_FileName, std::ios::binary |
+                                   std::ios::out);
 #endif
 
   if(!tmpWriteStream->rdbuf()->is_open())
@@ -890,13 +890,13 @@ Write(const char *_headName, const char *_dataName, bool _writeElements,
   }
 
 bool MetaArray::
-WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements,
+WriteStream(std::ofstream * _stream, bool _writeElements,
             const void *_constElementData)
   {
   if(m_WriteStream != nullptr)
     {
-    METAIO_STREAM::cout << "MetaArray: WriteStream: two files open?"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: WriteStream: two files open?"
+                        << std::endl;
     delete m_WriteStream;
     }
 
@@ -984,8 +984,8 @@ M_SetupReadFields()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: M_SetupReadFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: M_SetupReadFields"
+                        << std::endl;
     }
 
   MetaForm::M_SetupReadFields();
@@ -1056,20 +1056,20 @@ M_Read()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: M_Read: Loading Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: M_Read: Loading Header"
+                        << std::endl;
     }
   if(!MetaForm::M_Read())
     {
-    METAIO_STREAM::cout << "MetaArray: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: M_Read: Parsing Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaArray: M_Read: Parsing Header"
+                        << std::endl;
     }
   MET_FieldRecordType * mF;
 
@@ -1087,8 +1087,8 @@ M_Read()
       }
     else
       {
-      METAIO_STREAM::cout << "MetaArray: M_Read: Error: Length required"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaArray: M_Read: Error: Length required"
+                          << std::endl;
       return false;
       }
     }
@@ -1118,12 +1118,12 @@ M_Read()
 //
 //
 bool MetaArray::
-M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
+M_ReadElements(std::ifstream * _fstream, void * _data,
                int _dataQuantity)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: M_ReadElements" << METAIO_STREAM::endl;
+    std::cout << "MetaArray: M_ReadElements" << std::endl;
     }
 
   int elementSize;
@@ -1131,8 +1131,8 @@ M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
   int readSize = _dataQuantity*m_ElementNumberOfChannels*elementSize;
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaArray: M_ReadElements: ReadSize = "
-                        << readSize << METAIO_STREAM::endl;
+    std::cout << "MetaArray: M_ReadElements: ReadSize = "
+                        << readSize << std::endl;
     }
 
   // If compressed we inflate
@@ -1142,9 +1142,9 @@ M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
     // file is the size of the compressed data
     if(m_CompressedElementDataSize==0)
       {
-      _fstream->seekg(0, METAIO_STREAM::ios::end);
+      _fstream->seekg(0, std::ios::end);
       m_CompressedElementDataSize = _fstream->tellg();
-      _fstream->seekg(0, METAIO_STREAM::ios::beg);
+      _fstream->seekg(0, std::ios::beg);
       }
 
     unsigned char* compr = new unsigned char[static_cast<size_t>(m_CompressedElementDataSize)];
@@ -1171,12 +1171,12 @@ M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
       int gc = static_cast<int>(_fstream->gcount());
       if(gc != readSize)
         {
-        METAIO_STREAM::cout
+        std::cout
                   << "MetaArray: M_ReadElements: data not read completely"
-                  << METAIO_STREAM::endl;
-        METAIO_STREAM::cout << "   ideal = " << readSize
+                  << std::endl;
+        std::cout << "   ideal = " << readSize
                             << " : actual = " << gc
-                            << METAIO_STREAM::endl;
+                            << std::endl;
         return false;
         }
       }
@@ -1189,11 +1189,11 @@ M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
 //
 //
 bool MetaArray::
-M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data,
-               METAIO_STL::streamoff _dataQuantity)
+M_WriteElements(std::ofstream * _fstream, const void * _data,
+               std::streamoff _dataQuantity)
   {
   bool localData = false;
-  METAIO_STREAM::ofstream* tmpWriteStream;
+  std::ofstream* tmpWriteStream;
   if(!strcmp(m_ElementDataFileName, "LOCAL"))
     {
     localData = true;
@@ -1202,7 +1202,7 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data,
   else
     {
     localData = false;
-    tmpWriteStream = new METAIO_STREAM::ofstream;
+    tmpWriteStream = new std::ofstream;
 
     char dataFileName[1024];
     char pathName[255];
@@ -1220,13 +1220,13 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data,
 // that requires a file to exist for output
 #ifdef __sgi
     {
-    METAIO_STREAM::ofstream tFile(dataFileName, METAIO_STREAM::ios::out);
+    std::ofstream tFile(dataFileName, std::ios::out);
     tFile.close();
     }
-    tmpWriteStream->open(dataFileName, METAIO_STREAM::ios::out);
+    tmpWriteStream->open(dataFileName, std::ios::out);
 #else
-    tmpWriteStream->open(dataFileName, METAIO_STREAM::ios::binary |
-                                       METAIO_STREAM::ios::out);
+    tmpWriteStream->open(dataFileName, std::ios::binary |
+                                       std::ios::out);
 #endif
     }
 
@@ -1238,7 +1238,7 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data,
       MET_ValueToDouble(m_ElementType, _data, i, &tf);
       if((i+1)/10 == (double)(i+1.0)/10.0)
         {
-        (*tmpWriteStream) << tf << METAIO_STREAM::endl;
+        (*tmpWriteStream) << tf << std::endl;
         }
       else
         {

--- a/src/metaArray.h
+++ b/src/metaArray.h
@@ -151,9 +151,9 @@ class METAIO_EXPORT MetaArray : public MetaForm
                       void * _elementDataBuffer=NULL,
                       bool _autoFreeElementData=false);
 
-    virtual bool CanReadStream(METAIO_STREAM::ifstream * _stream) const;
+    virtual bool CanReadStream(std::ifstream * _stream) const;
 
-    virtual bool ReadStream(METAIO_STREAM::ifstream * _stream,
+    virtual bool ReadStream(std::ifstream * _stream,
                             bool _readElements=true,
                             void * _elementDataBuffer=NULL,
                             bool _autoFreeElementData=false);
@@ -163,7 +163,7 @@ class METAIO_EXPORT MetaArray : public MetaForm
                        bool _writeElements=true,
                        const void * _constElementData=NULL);
 
-    virtual bool WriteStream(METAIO_STREAM::ofstream * _stream,
+    virtual bool WriteStream(std::ofstream * _stream,
                              bool _writeElements=true,
                              const void * _constElementData=NULL);
 
@@ -182,7 +182,7 @@ class METAIO_EXPORT MetaArray : public MetaForm
 
     bool               m_AutoFreeElementData;
 
-    METAIO_STL::streamoff m_CompressedElementDataSize;
+    std::streamoff m_CompressedElementDataSize;
 
     char               m_ElementDataFileName[255];
 
@@ -196,13 +196,13 @@ class METAIO_EXPORT MetaArray : public MetaForm
 
     bool  M_Read(void) override;
 
-    bool  M_ReadElements(METAIO_STREAM::ifstream * _fstream,
+    bool  M_ReadElements(std::ifstream * _fstream,
                          void * _data,
                          int _dataQuantity);
 
-    bool  M_WriteElements(METAIO_STREAM::ofstream * _fstream,
+    bool  M_WriteElements(std::ofstream * _fstream,
                           const void * _data,
-                          METAIO_STL::streamoff _dataQuantity);
+                          std::streamoff _dataQuantity);
 
     };
 

--- a/src/metaArrow.cxx
+++ b/src/metaArrow.cxx
@@ -30,7 +30,7 @@ MetaArrow::
 MetaArrow()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaArrow()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaArrow()" << std::endl;
   Clear();
 }
 
@@ -39,7 +39,7 @@ MetaArrow::
 MetaArrow(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaArrow()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaArrow()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -49,7 +49,7 @@ MetaArrow::
 MetaArrow(const MetaArrow *_Arrow)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaArrow()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaArrow()" << std::endl;
   Clear();
   CopyInfo(_Arrow);
 }
@@ -58,7 +58,7 @@ MetaArrow::
 MetaArrow(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaArrow()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaArrow()" << std::endl;
   Clear();
   m_NDims = dim;
 }
@@ -75,13 +75,13 @@ void MetaArrow::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "Length = " << M_Length << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Direction = ";
+  std::cout << "Length = " << M_Length << std::endl;
+  std::cout << "Direction = ";
   for (int i = 0; i < m_NDims; i++)
     {
-    METAIO_STREAM::cout << M_Direction[i] << " ";
+    std::cout << M_Direction[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 }
 
 void MetaArrow::
@@ -144,7 +144,7 @@ Direction() const
 void MetaArrow::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaArrow: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaArrow: Clear" << std::endl;
   MetaObject::Clear();
   M_Length = 1;
 
@@ -164,7 +164,7 @@ M_Destroy()
 void MetaArrow::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaArrow: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaArrow: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -204,15 +204,15 @@ M_SetupWriteFields()
 bool MetaArrow::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaArrow: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaArrow: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaArrow: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaArrow: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaArrow: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaArrow: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF_length;
   mF_length = MET_GetFieldRecord("Length", &m_Fields);

--- a/src/metaBlob.cxx
+++ b/src/metaBlob.cxx
@@ -54,7 +54,7 @@ MetaBlob::
 MetaBlob()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob()" << std::endl;
   m_NPoints = 0;
   Clear();
 }
@@ -64,7 +64,7 @@ MetaBlob::
 MetaBlob(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaBlob()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaBlob()" << std::endl;
   m_NPoints = 0;
   Clear();
   Read(_headerName);
@@ -75,7 +75,7 @@ MetaBlob::
 MetaBlob(const MetaBlob *_blob)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaBlob()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaBlob()" << std::endl;
   m_NPoints = 0;
   Clear();
   CopyInfo(_blob);
@@ -88,7 +88,7 @@ MetaBlob::
 MetaBlob(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob()" << std::endl;
   m_NPoints = 0;
   Clear();
 }
@@ -106,11 +106,11 @@ void MetaBlob::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaBlob::
@@ -150,9 +150,9 @@ NPoints() const
 void MetaBlob::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob: Clear" << std::endl;
   MetaObject::Clear();
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob: Clear: m_NPoints" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob: Clear: m_NPoints" << std::endl;
   // Delete the list of pointers to blobs.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
@@ -178,7 +178,7 @@ M_Destroy()
 void MetaBlob::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -255,15 +255,15 @@ M_SetupWriteFields()
 bool MetaBlob::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaBlob: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaBlob: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaBlob: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaBlob: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 
@@ -335,9 +335,9 @@ M_Read()
     size_t gc = static_cast<size_t>(m_ReadStream->gcount());
     if(gc != readSize)
     {
-      METAIO_STREAM::cout << "MetaBlob: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaBlob: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc << std::endl;
       delete [] _data;
       delete [] posDim;
       return false;
@@ -431,8 +431,8 @@ M_Write()
 
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaBlob: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaBlob: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
@@ -486,7 +486,7 @@ M_Write()
         *m_WriteStream << (*it)->m_Color[d] << " ";
         }
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }

--- a/src/metaBlob.h
+++ b/src/metaBlob.h
@@ -67,7 +67,7 @@ class METAIO_EXPORT MetaBlob : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<BlobPnt*> PointListType;
+   typedef std::list<BlobPnt*> PointListType;
     ////
     //
     // Constructors & Destructor

--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -55,10 +55,10 @@ MetaCommand()
 
 
 /** Extract the date from a CVS Date keyword/value pair.  */
-METAIO_STL::string MetaCommand::
-ExtractDateFromCVS(METAIO_STL::string date)
+std::string MetaCommand::
+ExtractDateFromCVS(std::string date)
 {
-  METAIO_STL::string newdate;
+  std::string newdate;
   for(int i=7;i<(int)date.size()-1;i++)
     {
     newdate += date[i];
@@ -72,16 +72,16 @@ void MetaCommand::DisableDeprecatedWarnings()
 }
 
 void MetaCommand::
-SetDateFromCVS(METAIO_STL::string cvsDate)
+SetDateFromCVS(std::string cvsDate)
 {
   this->SetDate( this->ExtractDateFromCVS( cvsDate ).c_str() );
 }
 
 /** Extract the version from a CVS Revision keyword/value pair.  */
-METAIO_STL::string MetaCommand::
-ExtractVersionFromCVS(METAIO_STL::string version)
+std::string MetaCommand::
+ExtractVersionFromCVS(std::string version)
 {
-  METAIO_STL::string newversion;
+  std::string newversion;
   for(int i=11;i<(int)version.size()-1;i++)
     {
     newversion += version[i];
@@ -90,7 +90,7 @@ ExtractVersionFromCVS(METAIO_STL::string version)
 }
 
 void MetaCommand::
-SetVersionFromCVS(METAIO_STL::string cvsVersion)
+SetVersionFromCVS(std::string cvsVersion)
   {
   this->SetVersion( this->ExtractVersionFromCVS( cvsVersion ).c_str() );
   }
@@ -106,31 +106,31 @@ SetOption(Option option)
 }
 
 bool MetaCommand::
-SetOption(METAIO_STL::string name,
-                            METAIO_STL::string shortTag,
+SetOption(std::string name,
+                            std::string shortTag,
                             bool required,
-                            METAIO_STL::string description,
-                            METAIO_STL::vector<Field> fields)
+                            std::string description,
+                            std::vector<Field> fields)
 {
   // need to add some tests here to check if the option is not defined yet
   // Short tag can be empty as long as the long tag is defined.
   // This is checked in the Parse() command
   /*if(tag == "")
     {
-    METAIO_STREAM::cout << "Tag cannot be empty : use AddField() instead."
-                        << METAIO_STREAM::endl;
+    std::cout << "Tag cannot be empty : use AddField() instead."
+                        << std::endl;
     return false;
     }*/
   if(!m_DisableDeprecatedWarnings && shortTag.size()>1)
     {
-    METAIO_STREAM::cout << "Warning: as of August 23, 2007 MetaCommand::SetOption()"
+    std::cout << "Warning: as of August 23, 2007 MetaCommand::SetOption()"
               << " is expecting a shortTag of exactly one character."
               << " You should use the SetOptionLongTag(optionName,longTagName)"
               << " if you want to use a longer tag. The longtag will be"
               << " referred to as --LongTag and the short tag as -ShortTag."
               << " Replace -" << shortTag.c_str()
               << " by --" << shortTag.c_str()
-              << METAIO_STREAM::endl;
+              << std::endl;
     }
 
   Option option;
@@ -149,12 +149,12 @@ SetOption(METAIO_STL::string name,
 
 
 bool MetaCommand::
-SetOption(METAIO_STL::string name,
-          METAIO_STL::string shortTag,
+SetOption(std::string name,
+          std::string shortTag,
           bool required,
-          METAIO_STL::string description,
+          std::string description,
           TypeEnumType type,
-          METAIO_STL::string defVal,
+          std::string defVal,
           DataEnumType externalData)
 {
   // need to add some tests here to check if the option is not defined yet
@@ -163,21 +163,21 @@ SetOption(METAIO_STL::string name,
   /*
   if(tag == "")
     {
-    METAIO_STREAM::cout << "Tag cannot be empty : use AddField() instead."
-                        << METAIO_STREAM::endl;
+    std::cout << "Tag cannot be empty : use AddField() instead."
+                        << std::endl;
     return false;
     }*/
 
   if(!m_DisableDeprecatedWarnings && shortTag.size()>1)
     {
-    METAIO_STREAM::cout << "Warning: as of August 23, 2007 MetaCommand::SetOption() "
+    std::cout << "Warning: as of August 23, 2007 MetaCommand::SetOption() "
               << " is expecting a shortTag of exactly one character."
               << " You should use the SetOptionLongTag(optionName,longTagName)"
               << " if you want to use a longer tag. The longtag will be "
               << " referred to as --LongTag and the short tag as -ShortTag "
               << " Replace -" << shortTag.c_str()
               << " by --" << shortTag.c_str()
-              << METAIO_STREAM::endl;
+              << std::endl;
     }
 
   Option option;
@@ -215,12 +215,12 @@ SetOption(METAIO_STL::string name,
 
 /** Add a field */
 bool MetaCommand::
-AddField(METAIO_STL::string name,
-         METAIO_STL::string description,
+AddField(std::string name,
+         std::string description,
          TypeEnumType type,
          DataEnumType externalData,
-         METAIO_STL::string rangeMin,
-         METAIO_STL::string rangeMax)
+         std::string rangeMin,
+         std::string rangeMax)
 {
   // need to add some tests here to check if the option is not defined yet
   Option option;
@@ -250,8 +250,8 @@ AddField(METAIO_STL::string name,
 
 /** For backward compatibility */
 bool MetaCommand::
-AddField(METAIO_STL::string name,
-         METAIO_STL::string description,
+AddField(std::string name,
+         std::string description,
          TypeEnumType type,
          bool externalData)
 {
@@ -268,7 +268,7 @@ AddField(METAIO_STL::string name,
 /** Collect all the information until the next tag
   * \warning this function works only if the field is of type String */
 void MetaCommand::
-SetOptionComplete(METAIO_STL::string optionName,
+SetOptionComplete(std::string optionName,
                   bool complete)
 {
   OptionVector::iterator it = m_OptionVector.begin();
@@ -285,12 +285,12 @@ SetOptionComplete(METAIO_STL::string optionName,
 
 /** Add a field to a given an option */
 bool MetaCommand::
-AddOptionField(METAIO_STL::string optionName,
-               METAIO_STL::string name,
+AddOptionField(std::string optionName,
+               std::string name,
                TypeEnumType type,
                bool required,
-               METAIO_STL::string defVal,
-               METAIO_STL::string description,
+               std::string defVal,
+               std::string description,
                DataEnumType externalData)
 {
   OptionVector::iterator it = m_OptionVector.begin();
@@ -328,18 +328,18 @@ AddOptionField(METAIO_STL::string optionName,
 
 /** Set the range of an option */
 bool MetaCommand::
-SetOptionRange(METAIO_STL::string optionName,
-               METAIO_STL::string name,
-               METAIO_STL::string rangeMin,
-               METAIO_STL::string rangeMax)
+SetOptionRange(std::string optionName,
+               std::string name,
+               std::string rangeMin,
+               std::string rangeMax)
 {
   OptionVector::iterator it = m_OptionVector.begin();
   while(it != m_OptionVector.end())
     {
     if((*it).name == optionName)
       {
-      METAIO_STL::vector<Field> & fields = (*it).fields;
-      METAIO_STL::vector<Field>::iterator itField = fields.begin();
+      std::vector<Field> & fields = (*it).fields;
+      std::vector<Field>::iterator itField = fields.begin();
       while(itField != fields.end())
         {
         if((*itField).name == name)
@@ -358,9 +358,9 @@ SetOptionRange(METAIO_STL::string optionName,
 
 /** Set the range of an option */
 bool MetaCommand::
-SetOptionEnumerations(METAIO_STL::string optionName,
-                      METAIO_STL::string name,
-                      METAIO_STL::string optionEnums)
+SetOptionEnumerations(std::string optionName,
+                      std::string name,
+                      std::string optionEnums)
 
 {
   OptionVector::iterator it = m_OptionVector.begin();
@@ -368,8 +368,8 @@ SetOptionEnumerations(METAIO_STL::string optionName,
     {
     if((*it).name == optionName)
       {
-      METAIO_STL::vector<Field> & fields = (*it).fields;
-      METAIO_STL::vector<Field>::iterator itField = fields.begin();
+      std::vector<Field> & fields = (*it).fields;
+      std::vector<Field>::iterator itField = fields.begin();
       while(itField != fields.end())
         {
         if((*itField).name == name)
@@ -388,10 +388,10 @@ SetOptionEnumerations(METAIO_STL::string optionName,
 
 /** Return the value of the option as a boolean */
 bool MetaCommand::
-GetValueAsBool(METAIO_STL::string optionName,
-               METAIO_STL::string fieldName)
+GetValueAsBool(std::string optionName,
+               std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = optionName;
@@ -402,7 +402,7 @@ GetValueAsBool(METAIO_STL::string optionName,
     {
     if((*it).name == optionName)
       {
-      METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+      std::vector<Field>::const_iterator itField = (*it).fields.begin();
       while(itField != (*it).fields.end())
         {
         if((*itField).name == fieldname)
@@ -429,15 +429,15 @@ GetValueAsBool(METAIO_STL::string optionName,
 /** Return the value of the option as a bool */
 bool MetaCommand::
 GetValueAsBool(Option option,
-               METAIO_STL::string fieldName)
+               std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = option.name;
     }
 
-  METAIO_STL::vector<Field>::const_iterator itField = option.fields.begin();
+  std::vector<Field>::const_iterator itField = option.fields.begin();
   while(itField != option.fields.end())
     {
     if((*itField).name == fieldname)
@@ -459,10 +459,10 @@ GetValueAsBool(Option option,
 
 /** Return the value of the option as a float */
 float MetaCommand::
-GetValueAsFloat(METAIO_STL::string optionName,
-                METAIO_STL::string fieldName)
+GetValueAsFloat(std::string optionName,
+                std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = optionName;
@@ -473,7 +473,7 @@ GetValueAsFloat(METAIO_STL::string optionName,
     {
     if((*it).name == optionName)
       {
-      METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+      std::vector<Field>::const_iterator itField = (*it).fields.begin();
       while(itField != (*it).fields.end())
         {
         if((*itField).name == fieldname)
@@ -491,15 +491,15 @@ GetValueAsFloat(METAIO_STL::string optionName,
 /** Return the value of the option as a float */
 float MetaCommand::
 GetValueAsFloat(Option option,
-                METAIO_STL::string fieldName)
+                std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = option.name;
     }
 
-  METAIO_STL::vector<Field>::const_iterator itField = option.fields.begin();
+  std::vector<Field>::const_iterator itField = option.fields.begin();
   while(itField != option.fields.end())
     {
     if((*itField).name == fieldname)
@@ -513,10 +513,10 @@ GetValueAsFloat(Option option,
 
 /** Return the value of the option as a int */
 int MetaCommand::
-GetValueAsInt(METAIO_STL::string optionName,
-              METAIO_STL::string fieldName)
+GetValueAsInt(std::string optionName,
+              std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = optionName;
@@ -527,7 +527,7 @@ GetValueAsInt(METAIO_STL::string optionName,
     {
     if((*it).name == optionName)
       {
-      METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+      std::vector<Field>::const_iterator itField = (*it).fields.begin();
       while(itField != (*it).fields.end())
         {
         if((*itField).name == fieldname)
@@ -545,15 +545,15 @@ GetValueAsInt(METAIO_STL::string optionName,
 /** Return the value of the option as a int */
 int MetaCommand::
 GetValueAsInt(Option option,
-              METAIO_STL::string fieldName)
+              std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = option.name;
     }
 
-  METAIO_STL::vector<Field>::const_iterator itField = option.fields.begin();
+  std::vector<Field>::const_iterator itField = option.fields.begin();
   while(itField != option.fields.end())
     {
     if((*itField).name == fieldname)
@@ -566,11 +566,11 @@ GetValueAsInt(Option option,
 }
 
 /** Return the value of the option as a string */
-METAIO_STL::string MetaCommand::
-GetValueAsString(METAIO_STL::string optionName,
-                 METAIO_STL::string fieldName)
+std::string MetaCommand::
+GetValueAsString(std::string optionName,
+                 std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = optionName;
@@ -581,7 +581,7 @@ GetValueAsString(METAIO_STL::string optionName,
     {
     if((*it).name == optionName)
       {
-      METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+      std::vector<Field>::const_iterator itField = (*it).fields.begin();
       while(itField != (*it).fields.end())
         {
         if((*itField).name == fieldname)
@@ -597,17 +597,17 @@ GetValueAsString(METAIO_STL::string optionName,
 }
 
 /** Return the value of the option as a string */
-METAIO_STL::string MetaCommand::
+std::string MetaCommand::
 GetValueAsString(Option option,
-                 METAIO_STL::string fieldName)
+                 std::string fieldName)
 {
-  METAIO_STL::string fieldname = fieldName;
+  std::string fieldname = fieldName;
   if(fieldName == "")
     {
     fieldname = option.name;
     }
 
-  METAIO_STL::vector<Field>::const_iterator itField = option.fields.begin();
+  std::vector<Field>::const_iterator itField = option.fields.begin();
   while(itField != option.fields.end())
     {
     if((*itField).name == fieldname)
@@ -620,12 +620,12 @@ GetValueAsString(Option option,
 }
 
 /** Return the value of the option as a list of strings */
-METAIO_STL::list<METAIO_STL::string> MetaCommand::
+std::list<std::string> MetaCommand::
 GetValueAsList( Option option )
 {
-  METAIO_STL::list<METAIO_STL::string> results;
+  std::list<std::string> results;
   results.clear();
-  METAIO_STL::vector<Field>::const_iterator itField = option.fields.begin();
+  std::vector<Field>::const_iterator itField = option.fields.begin();
   ++itField;
   while(itField != option.fields.end())
     {
@@ -635,8 +635,8 @@ GetValueAsList( Option option )
   return results;
 }
 
-METAIO_STL::list< METAIO_STL::string > MetaCommand::
-GetValueAsList( METAIO_STL::string optionName )
+std::list< std::string > MetaCommand::
+GetValueAsList( std::string optionName )
 {
   OptionVector::const_iterator it = m_OptionVector.begin();
   while(it != m_OptionVector.end())
@@ -647,7 +647,7 @@ GetValueAsList( METAIO_STL::string optionName )
       }
     ++it;
     }
-  METAIO_STL::list< METAIO_STL::string > empty;
+  std::list< std::string > empty;
   empty.clear();
   return empty;
 }
@@ -663,7 +663,7 @@ GetOptionWasSet(Option option)
 }
 
 bool MetaCommand::
-GetOptionWasSet( METAIO_STL::string optionName)
+GetOptionWasSet( std::string optionName)
 {
   OptionVector::const_iterator it = m_ParsedOptionVector.begin();
   while(it != m_ParsedOptionVector.end())
@@ -685,94 +685,94 @@ ListOptions()
   int i=0;
   while(it != m_OptionVector.end())
     {
-    METAIO_STREAM::cout << "Option #" << i << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "   Name: " <<  (*it).name.c_str()
-                        << METAIO_STREAM::endl;
+    std::cout << "Option #" << i << std::endl;
+    std::cout << "   Name: " <<  (*it).name.c_str()
+                        << std::endl;
     if((*it).tag.size() > 0)
       {
-      METAIO_STREAM::cout << "   Tag: " << (*it).tag.c_str()
-                          << METAIO_STREAM::endl;
+      std::cout << "   Tag: " << (*it).tag.c_str()
+                          << std::endl;
       }
     if((*it).longtag.size() > 0)
       {
-      METAIO_STREAM::cout << "   LongTag: " << (*it).longtag.c_str()
-                          << METAIO_STREAM::endl;
+      std::cout << "   LongTag: " << (*it).longtag.c_str()
+                          << std::endl;
       }
-    METAIO_STREAM::cout << "   Description: " << (*it).description.c_str()
-                        << METAIO_STREAM::endl;
+    std::cout << "   Description: " << (*it).description.c_str()
+                        << std::endl;
     if((*it).required)
       {
-      METAIO_STREAM::cout << "   Required: true" << METAIO_STREAM::endl;
+      std::cout << "   Required: true" << std::endl;
       }
     else
       {
-      METAIO_STREAM::cout << "   Required: false" << METAIO_STREAM::endl;
+      std::cout << "   Required: false" << std::endl;
       }
-    METAIO_STREAM::cout << "   Number of expected values: "
+    std::cout << "   Number of expected values: "
                         << (*it).fields.size()
-                        << METAIO_STREAM::endl;
+                        << std::endl;
 
-    METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+    std::vector<Field>::const_iterator itField = (*it).fields.begin();
     while(itField != (*it).fields.end())
       {
-      METAIO_STREAM::cout << "      Field Name: " <<  (*itField).name.c_str()
-                          << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "      Description: "
+      std::cout << "      Field Name: " <<  (*itField).name.c_str()
+                          << std::endl;
+      std::cout << "      Description: "
                           << (*itField).description.c_str()
-                          << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "      Type: "
+                          << std::endl;
+      std::cout << "      Type: "
                           << this->TypeToString((*itField).type).c_str()
-                          << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "      Value: " << (*itField).value.c_str()
-                          << METAIO_STREAM::endl;
+                          << std::endl;
+      std::cout << "      Value: " << (*itField).value.c_str()
+                          << std::endl;
       if( (*itField).type == ENUM )
         {
-        METAIO_STREAM::cout << "      Enum list: "
+        std::cout << "      Enum list: "
                             << (*itField).rangeMin.c_str()
-                            << METAIO_STREAM::endl;
+                            << std::endl;
         }
       else
         {
-        METAIO_STREAM::cout << "      RangeMin: "
+        std::cout << "      RangeMin: "
                             << (*itField).rangeMin.c_str()
-                            << METAIO_STREAM::endl;
-        METAIO_STREAM::cout << "      RangeMax: "
+                            << std::endl;
+        std::cout << "      RangeMax: "
                             << (*itField).rangeMax.c_str()
-                            << METAIO_STREAM::endl;
+                            << std::endl;
         }
 
       if((*itField).externaldata)
         {
-        METAIO_STREAM::cout << "      External Data: true"
-                            << METAIO_STREAM::endl;
+        std::cout << "      External Data: true"
+                            << std::endl;
         }
       else
         {
-        METAIO_STREAM::cout << "      External Data: false"
-                            << METAIO_STREAM::endl;
+        std::cout << "      External Data: false"
+                            << std::endl;
         }
 
       if((*itField).required)
         {
-        METAIO_STREAM::cout << "      Required: true" << METAIO_STREAM::endl;
+        std::cout << "      Required: true" << std::endl;
         }
       else
         {
-        METAIO_STREAM::cout << "      Required: false" << METAIO_STREAM::endl;
+        std::cout << "      Required: false" << std::endl;
         }
 
       if((*itField).userDefined)
         {
-        METAIO_STREAM::cout << "      User Defined: true" << METAIO_STREAM::endl;
+        std::cout << "      User Defined: true" << std::endl;
         }
       else
         {
-        METAIO_STREAM::cout << "      User Defined: false" << METAIO_STREAM::endl;
+        std::cout << "      User Defined: false" << std::endl;
         }
 
       ++itField;
       }
-    METAIO_STREAM::cout << METAIO_STREAM::endl;
+    std::cout << std::endl;
     i++;
     ++it;
     }
@@ -789,78 +789,78 @@ void MetaCommand::ListOptionsXML()
   int i=0;
   while(it != m_OptionVector.end())
     {
-    METAIO_STREAM::cout << "<option>" << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "<number>" << i << "</number>"
-                        << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "<name>" << (*it).name.c_str() << "</name>"
-                        << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "<tag>" << (*it).tag.c_str() << "</tag>"
-                        << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "<longtag>" << (*it).longtag.c_str() << "</longtag>"
-                        << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "<description>" << (*it).description.c_str()
-                        << "</description>" << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "<required>";
+    std::cout << "<option>" << std::endl;
+    std::cout << "<number>" << i << "</number>"
+                        << std::endl;
+    std::cout << "<name>" << (*it).name.c_str() << "</name>"
+                        << std::endl;
+    std::cout << "<tag>" << (*it).tag.c_str() << "</tag>"
+                        << std::endl;
+    std::cout << "<longtag>" << (*it).longtag.c_str() << "</longtag>"
+                        << std::endl;
+    std::cout << "<description>" << (*it).description.c_str()
+                        << "</description>" << std::endl;
+    std::cout << "<required>";
     if((*it).required)
       {
-      METAIO_STREAM::cout << "1</required>" << METAIO_STREAM::endl;
+      std::cout << "1</required>" << std::endl;
       }
     else
       {
-      METAIO_STREAM::cout << "0</required>" << METAIO_STREAM::endl;
+      std::cout << "0</required>" << std::endl;
       }
 
-    METAIO_STREAM::cout << "<nvalues>" << (*it).fields.size() << "</nvalues>"
-                        << METAIO_STREAM::endl;
+    std::cout << "<nvalues>" << (*it).fields.size() << "</nvalues>"
+                        << std::endl;
 
-    METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+    std::vector<Field>::const_iterator itField = (*it).fields.begin();
     while(itField != (*it).fields.end())
       {
-      METAIO_STREAM::cout << "<field>" << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "<name>" << (*itField).name.c_str() << "</name>"
-                          << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "<description>" << (*itField).description.c_str()
-                          << "</description>" << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "<type>"
+      std::cout << "<field>" << std::endl;
+      std::cout << "<name>" << (*itField).name.c_str() << "</name>"
+                          << std::endl;
+      std::cout << "<description>" << (*itField).description.c_str()
+                          << "</description>" << std::endl;
+      std::cout << "<type>"
                           << this->TypeToString((*itField).type).c_str()
-                          << "</type>" << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "<value>" << (*itField).value.c_str()
-                          << "</value>" << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "<external>";
+                          << "</type>" << std::endl;
+      std::cout << "<value>" << (*itField).value.c_str()
+                          << "</value>" << std::endl;
+      std::cout << "<external>";
       if((*itField).externaldata == DATA_IN)
         {
-        METAIO_STREAM::cout << "1</external>" << METAIO_STREAM::endl;
+        std::cout << "1</external>" << std::endl;
         }
       else if((*itField).externaldata == DATA_OUT)
         {
-        METAIO_STREAM::cout << "2</external>" << METAIO_STREAM::endl;
+        std::cout << "2</external>" << std::endl;
         }
       else
         {
-        METAIO_STREAM::cout << "0</external>" << METAIO_STREAM::endl;
+        std::cout << "0</external>" << std::endl;
         }
-      METAIO_STREAM::cout << "<required>";
+      std::cout << "<required>";
       if((*itField).required)
         {
-        METAIO_STREAM::cout << "1</required>" << METAIO_STREAM::endl;
+        std::cout << "1</required>" << std::endl;
         }
       else
         {
-        METAIO_STREAM::cout << "0</required>" << METAIO_STREAM::endl;
+        std::cout << "0</required>" << std::endl;
         }
 
 
-      METAIO_STREAM::cout << "</field>" << METAIO_STREAM::endl;
+      std::cout << "</field>" << std::endl;
       ++itField;
       }
-    METAIO_STREAM::cout << "</option>" << METAIO_STREAM::endl;
+    std::cout << "</option>" << std::endl;
     i++;
     ++it;
     }
 }
 
 /** Used by ListOptionsSlicerXML */
-void MetaCommand::WriteXMLOptionToCout(METAIO_STL::string optionName,
+void MetaCommand::WriteXMLOptionToCout(std::string optionName,
                                        unsigned int & index)
 {
   OptionVector::const_iterator it = m_OptionVector.begin();
@@ -873,9 +873,9 @@ void MetaCommand::WriteXMLOptionToCout(METAIO_STL::string optionName,
     ++it;
     }
 
-  METAIO_STL::vector<Field>::const_iterator itField = (*it).fields.begin();
+  std::vector<Field>::const_iterator itField = (*it).fields.begin();
 
-  METAIO_STL::string optionType = "";
+  std::string optionType = "";
 
   if((*itField).type == MetaCommand::STRING
      && ( (*itField).externaldata == MetaCommand::DATA_IN
@@ -900,143 +900,143 @@ void MetaCommand::WriteXMLOptionToCout(METAIO_STL::string optionName,
     optionType = this->TypeToString((*itField).type).c_str();
     }
 
-  METAIO_STREAM::cout << "<" << optionType.c_str()
-                      << ">" << METAIO_STREAM::endl;
+  std::cout << "<" << optionType.c_str()
+                      << ">" << std::endl;
 
 
-  METAIO_STREAM::cout << "<name>" << (*it).name.c_str() << "</name>"
-                      << METAIO_STREAM::endl;
+  std::cout << "<name>" << (*it).name.c_str() << "</name>"
+                      << std::endl;
   // Label is the description for now
-  METAIO_STL::string label = (*it).label;
+  std::string label = (*it).label;
   if(label.size()==0)
     {
     label = (*it).name;
     }
 
-  METAIO_STREAM::cout << "<label>" << label.c_str() << "</label>"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "<description>" << (*it).description.c_str()
-                      << "</description>" << METAIO_STREAM::endl;
+  std::cout << "<label>" << label.c_str() << "</label>"
+                      << std::endl;
+  std::cout << "<description>" << (*it).description.c_str()
+                      << "</description>" << std::endl;
   if((*it).tag.size()>0) // use the single by default flag if any
     {
-    METAIO_STREAM::cout << "<flag>" << (*it).tag.c_str() << "</flag>"
-                        << METAIO_STREAM::endl;
+    std::cout << "<flag>" << (*it).tag.c_str() << "</flag>"
+                        << std::endl;
     }
   else if((*it).longtag.size()>0)
     {
-    METAIO_STREAM::cout << "<longflag>" << (*it).longtag.c_str() << "</longflag>"
-                        << METAIO_STREAM::endl;
+    std::cout << "<longflag>" << (*it).longtag.c_str() << "</longflag>"
+                        << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "<index>" << index << "</index>" << METAIO_STREAM::endl;
+    std::cout << "<index>" << index << "</index>" << std::endl;
     index++;
     }
 
   if((*itField).value.size()>0)
     {
-    METAIO_STREAM::cout << "<default>" << (*itField).value.c_str() << "</default>"
-                        << METAIO_STREAM::endl;
+    std::cout << "<default>" << (*itField).value.c_str() << "</default>"
+                        << std::endl;
     }
 
   if((*itField).externaldata == MetaCommand::DATA_IN)
     {
-    METAIO_STREAM::cout << "<channel>input</channel>" << METAIO_STREAM::endl;
+    std::cout << "<channel>input</channel>" << std::endl;
     }
   else if((*itField).externaldata == MetaCommand::DATA_OUT)
     {
-    METAIO_STREAM::cout << "<channel>output</channel>" << METAIO_STREAM::endl;
+    std::cout << "<channel>output</channel>" << std::endl;
     }
 
   if((*itField).type == MetaCommand::ENUM)
     {
-    METAIO_STL::vector< METAIO_STL::string > enumVector;
-    MET_StringToVector< METAIO_STL::string>( (*itField).rangeMin, enumVector );
-    METAIO_STL::vector< METAIO_STL::string >::iterator itenum;
+    std::vector< std::string > enumVector;
+    MET_StringToVector< std::string>( (*itField).rangeMin, enumVector );
+    std::vector< std::string >::iterator itenum;
     itenum = enumVector.begin();
     while(itenum != enumVector.end() )
       {
-      METAIO_STREAM::cout << "<element>" << (*itenum).c_str() << "</element>"
-                          << METAIO_STREAM::endl;
+      std::cout << "<element>" << (*itenum).c_str() << "</element>"
+                          << std::endl;
       ++itenum;
       }
     }
 
   // Write out the closing tag
-  METAIO_STREAM::cout << "</" << optionType.c_str()
-                      << ">" << METAIO_STREAM::endl;
+  std::cout << "</" << optionType.c_str()
+                      << ">" << std::endl;
 }
 
 /** List the current options in Slicer's xml format (www.slicer.org) */
 void MetaCommand::ListOptionsSlicerXML()
 {
-  METAIO_STREAM::cout << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "<executable>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <category>" << m_Category.c_str() << "</category>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <title>" << m_Name.c_str() << "</title>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <description>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  " << m_Description.c_str() <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  </description>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <version>" << m_Version.c_str() << "</version>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <contributor>" << m_Author.c_str() << "</contributor>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <documentation-url></documentation-url>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <license></license>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  <acknowledgements>" <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  " << m_Acknowledgments.c_str() <<  METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "  </acknowledgements>" <<  METAIO_STREAM::endl;
+  std::cout << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" <<  std::endl;
+  std::cout << "<executable>" <<  std::endl;
+  std::cout << "  <category>" << m_Category.c_str() << "</category>" <<  std::endl;
+  std::cout << "  <title>" << m_Name.c_str() << "</title>" <<  std::endl;
+  std::cout << "  <description>" <<  std::endl;
+  std::cout << "  " << m_Description.c_str() <<  std::endl;
+  std::cout << "  </description>" <<  std::endl;
+  std::cout << "  <version>" << m_Version.c_str() << "</version>" <<  std::endl;
+  std::cout << "  <contributor>" << m_Author.c_str() << "</contributor>" <<  std::endl;
+  std::cout << "  <documentation-url></documentation-url>" <<  std::endl;
+  std::cout << "  <license></license>" <<  std::endl;
+  std::cout << "  <acknowledgements>" <<  std::endl;
+  std::cout << "  " << m_Acknowledgments.c_str() <<  std::endl;
+  std::cout << "  </acknowledgements>" <<  std::endl;
 
   // Organize by group first
   // Keep a list of options
   unsigned int index=0;
-  METAIO_STL::vector<METAIO_STL::string>   GroupedOptionVector;
+  std::vector<std::string>   GroupedOptionVector;
   ParameterGroupVector::const_iterator itGroup = m_ParameterGroup.begin();
   while(itGroup != m_ParameterGroup.end())
     {
     if( (*itGroup).advanced == true )
       {
-      METAIO_STREAM::cout << " <parameters advanced=\"true\">" <<  METAIO_STREAM::endl;
+      std::cout << " <parameters advanced=\"true\">" <<  std::endl;
       }
     else
       {
-      METAIO_STREAM::cout << " <parameters>" <<  METAIO_STREAM::endl;
+      std::cout << " <parameters>" <<  std::endl;
       }
-    METAIO_STREAM::cout << "  <label>" << (*itGroup).name.c_str()
-                        <<  "</label>" <<  METAIO_STREAM::endl;
+    std::cout << "  <label>" << (*itGroup).name.c_str()
+                        <<  "</label>" <<  std::endl;
 
     if((*itGroup).description.size() == 0)
       {
-      METAIO_STREAM::cout << "  <description>" << (*itGroup).name.c_str()
-                          << "</description>" <<  METAIO_STREAM::endl;
+      std::cout << "  <description>" << (*itGroup).name.c_str()
+                          << "</description>" <<  std::endl;
       }
     else
       {
-      METAIO_STREAM::cout << "  <description>" << (*itGroup).description.c_str()
-                          << "</description>" <<  METAIO_STREAM::endl;
+      std::cout << "  <description>" << (*itGroup).description.c_str()
+                          << "</description>" <<  std::endl;
       }
 
-    METAIO_STL::vector<METAIO_STL::string>::const_iterator itOption = (*itGroup).options.begin();
+    std::vector<std::string>::const_iterator itOption = (*itGroup).options.begin();
     while(itOption != (*itGroup).options.end())
       {
       this->WriteXMLOptionToCout(*itOption,index);
       GroupedOptionVector.push_back(*itOption);
       ++itOption;
       }
-    METAIO_STREAM::cout << " </parameters>" <<  METAIO_STREAM::endl;
+    std::cout << " </parameters>" <<  std::endl;
     ++itGroup;
     }
 
   // Then take the remaining options
   if(m_OptionVector.size()>GroupedOptionVector.size())
     {
-    METAIO_STREAM::cout << " <parameters>" <<  METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "  <label>IO</label>" <<  METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "  <description>Input/output parameters</description>" <<  METAIO_STREAM::endl;
+    std::cout << " <parameters>" <<  std::endl;
+    std::cout << "  <label>IO</label>" <<  std::endl;
+    std::cout << "  <description>Input/output parameters</description>" <<  std::endl;
 
     OptionVector::const_iterator it = m_OptionVector.begin();
     while(it != m_OptionVector.end())
       {
       bool optionIsGrouped = false;
-      METAIO_STL::vector<METAIO_STL::string>::const_iterator itGroupedOption = GroupedOptionVector.begin();
+      std::vector<std::string>::const_iterator itGroupedOption = GroupedOptionVector.begin();
       while(itGroupedOption != GroupedOptionVector.end())
         {
         if(!strcmp((*itGroupedOption).c_str(),(*it).name.c_str()))
@@ -1054,25 +1054,25 @@ void MetaCommand::ListOptionsSlicerXML()
       ++it;
       } // end loop option
 
-    METAIO_STREAM::cout << " </parameters>" <<  METAIO_STREAM::endl;
+    std::cout << " </parameters>" <<  std::endl;
     } // end m_OptionVector.size()>GroupedOptionVector.size()
 
-METAIO_STREAM::cout << "</executable>" <<  METAIO_STREAM::endl;
+std::cout << "</executable>" <<  std::endl;
 }
 
 
 /** Internal small XML parser */
-METAIO_STL::string MetaCommand::
+std::string MetaCommand::
 GetXML(const char* buffer, const char* desc, unsigned long pos)
 {
-  METAIO_STL::string begin = "<";
+  std::string begin = "<";
   begin += desc;
   begin += ">";
-  METAIO_STL::string end = "</";
+  std::string end = "</";
   end += desc;
   end += ">";
 
-  METAIO_STL::string buf = buffer;
+  std::string buf = buffer;
 
   long int posb = static_cast<long int>(buf.find(begin,pos));
   if(posb == -1)
@@ -1093,7 +1093,7 @@ bool MetaCommand::
 ParseXML(const char* buffer)
 {
   m_OptionVector.clear();
-  METAIO_STL::string buf = this->GetXML(buffer,"option",0);
+  std::string buf = this->GetXML(buffer,"option",0);
   long pos = 0;
   while(buf.size() > 0)
     {
@@ -1118,7 +1118,7 @@ ParseXML(const char* buffer)
     long posF = static_cast<long>(buf.find("<field>"));
     for(unsigned int i=0;i<n;i++)
       {
-      METAIO_STL::string f = this->GetXML(buf.c_str(),"field",posF);
+      std::string f = this->GetXML(buf.c_str(),"field",posF);
       Field field;
       field.userDefined = false;
       field.name = this->GetXML(f.c_str(),"name",0);
@@ -1169,40 +1169,40 @@ ListOptionsSimplified(bool extended)
 {
   if(extended)
     {
-    METAIO_STREAM::cout << " System tags: " << METAIO_STREAM::endl
+    std::cout << " System tags: " << std::endl
             << "   [ -v ] or [ -h ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = List options in short format"
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ -V ] or [ -H ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = List options in long format"
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ -vxml ] or [ -hxml ] or [ -exportXML ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = List options in xml format for BatchMake"
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ --xml ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = List options in xml format for Slicer"
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ -vgad ] or [ -hgad ] or [ -exportGAD ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = List options in Grid Application Description format"
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ -version ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = return the version number"
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ -date ]"
-            << METAIO_STREAM::endl
+            << std::endl
             << "      = return the cvs checkout date"
 #ifdef METAIO_USE_LIBXML2
-            << METAIO_STREAM::endl
+            << std::endl
             << "   [ --loadArguments filename ]"
             << "      = load the arguments from an XML file"
 #endif
-            << METAIO_STREAM::endl;
+            << std::endl;
      }
 
   int count = 0;
@@ -1228,8 +1228,8 @@ ListOptionsSimplified(bool extended)
       {
       if(ntags > 0)
         {
-        METAIO_STREAM::cout << " Command tags: "
-                            << METAIO_STREAM::endl;
+        std::cout << " Command tags: "
+                            << std::endl;
         }
       else
         {
@@ -1240,8 +1240,8 @@ ListOptionsSimplified(bool extended)
       {
       if(nfields > 0)
         {
-        METAIO_STREAM::cout << " Command fields: "
-                            << METAIO_STREAM::endl;
+        std::cout << " Command fields: "
+                            << std::endl;
         }
       else
         {
@@ -1257,21 +1257,21 @@ ListOptionsSimplified(bool extended)
         {
         if(!(*it).required)
           {
-          METAIO_STREAM::cout << "   [ ";
+          std::cout << "   [ ";
           }
         else
           {
-          METAIO_STREAM::cout << "   ";
+          std::cout << "   ";
           }
         if((*it).tag.size() > 0)
           {
-          METAIO_STREAM::cout << "-" << (*it).tag.c_str() << " ";
+          std::cout << "-" << (*it).tag.c_str() << " ";
           }
         if((*it).longtag.size() > 0)
           {
-          METAIO_STREAM::cout << "--" << (*it).longtag.c_str() << " ";
+          std::cout << "--" << (*it).longtag.c_str() << " ";
           }
-        METAIO_STL::vector<Field>::const_iterator itField =
+        std::vector<Field>::const_iterator itField =
                                                   (*it).fields.begin();
         while(itField != (*it).fields.end())
           {
@@ -1280,22 +1280,22 @@ ListOptionsSimplified(bool extended)
             {
             if((*itField).required)
               {
-              METAIO_STREAM::cout << "< ";
+              std::cout << "< ";
               }
             else
               {
-              METAIO_STREAM::cout << "[ ";
+              std::cout << "[ ";
               }
 
-            METAIO_STREAM::cout << (*itField).name.c_str();
+            std::cout << (*itField).name.c_str();
 
             if((*itField).required)
               {
-              METAIO_STREAM::cout << " > ";
+              std::cout << " > ";
               }
             else
               {
-              METAIO_STREAM::cout << " ] ";
+              std::cout << " ] ";
               }
             }
           ++itField;
@@ -1303,32 +1303,32 @@ ListOptionsSimplified(bool extended)
 
         if(!(*it).required)
           {
-          METAIO_STREAM::cout << "]";
+          std::cout << "]";
           }
-        METAIO_STREAM::cout << METAIO_STREAM::endl;
+        std::cout << std::endl;
 
         if((*it).description.size()>0)
           {
-          METAIO_STREAM::cout << "      = " << (*it).description.c_str();
-          METAIO_STREAM::cout << METAIO_STREAM::endl;
+          std::cout << "      = " << (*it).description.c_str();
+          std::cout << std::endl;
           itField = (*it).fields.begin();
           while(itField != (*it).fields.end())
             {
             if((*itField).description.size() > 0
                || (*itField).value.size() > 0)
               {
-              METAIO_STREAM::cout << "        With: "
+              std::cout << "        With: "
                                   << (*itField).name.c_str();
               if((*itField).description.size() > 0)
                 {
-                METAIO_STREAM::cout << " = " << (*itField).description.c_str();
+                std::cout << " = " << (*itField).description.c_str();
                 }
               if((*itField).value.size() > 0)
                 {
-                METAIO_STREAM::cout << " (Default = "
+                std::cout << " (Default = "
                                     << (*itField).value.c_str() << ")";
                 }
-              METAIO_STREAM::cout << METAIO_STREAM::endl;
+              std::cout << std::endl;
               }
             ++itField;
             }
@@ -1347,16 +1347,16 @@ ListOptionsSimplified(bool extended)
 /** Get the option by "-"+tag
  *  or by "--"+longtag */
 bool MetaCommand::
-OptionExistsByMinusTag(METAIO_STL::string minusTag)
+OptionExistsByMinusTag(std::string minusTag)
 {
   OptionVector::const_iterator it = m_OptionVector.begin();
   while(it != m_OptionVector.end())
     {
-    METAIO_STL::string tagToSearch = "-";
+    std::string tagToSearch = "-";
     tagToSearch += (*it).tag;
-    METAIO_STL::string longtagToSearch = "--";
+    std::string longtagToSearch = "--";
     longtagToSearch += (*it).longtag;
-    METAIO_STL::string longtagToSearchBackwardCompatible = "-";
+    std::string longtagToSearchBackwardCompatible = "-";
     longtagToSearchBackwardCompatible += (*it).longtag;
     // WARNING: This is for backward compatibility but a warning
     // is going to be thrown if used so that people can adjust
@@ -1375,16 +1375,16 @@ OptionExistsByMinusTag(METAIO_STL::string minusTag)
 /** Get the option by "-"+tag
  *  or by "--"+longtag */
 MetaCommand::Option * MetaCommand::
-GetOptionByMinusTag(METAIO_STL::string minusTag)
+GetOptionByMinusTag(std::string minusTag)
 {
   OptionVector::iterator it = m_OptionVector.begin();
   while(it != m_OptionVector.end())
     {
-    METAIO_STL::string tagToSearch = "-";
+    std::string tagToSearch = "-";
     tagToSearch += (*it).tag;
-    METAIO_STL::string longtagToSearch = "--";
+    std::string longtagToSearch = "--";
     longtagToSearch += (*it).longtag;
-    METAIO_STL::string longtagToSearchBackwardCompatible = "-";
+    std::string longtagToSearchBackwardCompatible = "-";
     longtagToSearchBackwardCompatible += (*it).longtag;
 
     // WARNING: This is for backward compatibility but a warning
@@ -1403,7 +1403,7 @@ GetOptionByMinusTag(METAIO_STL::string minusTag)
 
 /** Get the option by tag */
 MetaCommand::Option * MetaCommand::
-GetOptionByTag(METAIO_STL::string tag)
+GetOptionByTag(std::string tag)
 {
   OptionVector::iterator it = m_OptionVector.begin();
   while(it != m_OptionVector.end())
@@ -1440,7 +1440,7 @@ GetOptionId(Option* option)
 bool MetaCommand::
 ExportGAD(bool dynamic)
 {
-  METAIO_STREAM::cout << "Exporting GAD file...";
+  std::cout << "Exporting GAD file...";
 
   OptionVector options = m_OptionVector;
   if(dynamic)
@@ -1450,70 +1450,70 @@ ExportGAD(bool dynamic)
 
   if(m_Name=="")
     {
-    METAIO_STREAM::cout << "Set the name of the application using SetName()"
-                        << METAIO_STREAM::endl;
+    std::cout << "Set the name of the application using SetName()"
+                        << std::endl;
     return false;
     }
 
-  METAIO_STL::string filename = m_Name;
+  std::string filename = m_Name;
   filename += ".gad.xml";
 
-  METAIO_STREAM::ofstream file;
+  std::ofstream file;
 #ifdef __sgi
-  file.open(filename.c_str(), METAIO_STREAM::ios::out);
+  file.open(filename.c_str(), std::ios::out);
 #else
-  file.open(filename.c_str(), METAIO_STREAM::ios::binary
-                              | METAIO_STREAM::ios::out);
+  file.open(filename.c_str(), std::ios::binary
+                              | std::ios::out);
 #endif
   if(!file.rdbuf()->is_open())
     {
-    METAIO_STREAM::cout << "Cannot open file for writing: "
-                        << filename.c_str() <<  METAIO_STREAM::endl;
+    std::cout << "Cannot open file for writing: "
+                        << filename.c_str() <<  std::endl;
     return false;
     }
 
-  file << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" << METAIO_STREAM::endl;
-  file << "<gridApplication" << METAIO_STREAM::endl;
+  file << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" << std::endl;
+  file << "<gridApplication" << std::endl;
   file << "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
-       << METAIO_STREAM::endl;
+       << std::endl;
   file << "xsi:noNamespaceSchemaLocation=\"grid-application-description.xsd\""
-       << METAIO_STREAM::endl;
-  file << "name=\"" << m_Name.c_str() << "\"" << METAIO_STREAM::endl;
+       << std::endl;
+  file << "name=\"" << m_Name.c_str() << "\"" << std::endl;
   file << "description=\"" << m_Description.c_str() << "\">"
-       << METAIO_STREAM::endl;
+       << std::endl;
   file << "<applicationComponent name=\"Client\" remoteExecution=\"true\">"
-       << METAIO_STREAM::endl;
-  file << "<componentActionList>" << METAIO_STREAM::endl;
-  file << METAIO_STREAM::endl;
+       << std::endl;
+  file << "<componentActionList>" << std::endl;
+  file << std::endl;
 
   unsigned int order = 1;
   // Write out the input data to be transferred
   OptionVector::const_iterator it = options.begin();
   while(it != options.end())
     {
-    METAIO_STL::vector<Field>::const_iterator itFields = (*it).fields.begin();
+    std::vector<Field>::const_iterator itFields = (*it).fields.begin();
     while(itFields != (*it).fields.end())
       {
       if((*itFields).externaldata == DATA_IN)
         {
         file << " <componentAction type=\"DataRelocation\" order=\"" << order
-             << "\">" << METAIO_STREAM::endl;
+             << "\">" << std::endl;
         file << "  <parameter name=\"Name\" value=\""
              << (*itFields).name.c_str()
-             <<"\"/>" << METAIO_STREAM::endl;
+             <<"\"/>" << std::endl;
         file << "  <parameter name=\"Host\" value=\"hostname\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"Description\" value=\""
              << (*itFields).description.c_str() << "\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"Direction\" value=\"In\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"Protocol\" value=\"gsiftp\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"SourceDataPath\" value=\""
-             << (*itFields).value.c_str() << "\"/>" << METAIO_STREAM::endl;
+             << (*itFields).value.c_str() << "\"/>" << std::endl;
 
-        METAIO_STL::string datapath = (*itFields).value;
+        std::string datapath = (*itFields).value;
         long int slash = static_cast<long int>(datapath.find_last_of('/'));
         if(slash>0)
           {
@@ -1525,9 +1525,9 @@ ExportGAD(bool dynamic)
           datapath = datapath.substr(slash+1,datapath.size()-slash-1);
           }
         file << "  <parameter name=\"DestDataPath\" value=\""
-             << datapath.c_str() << "\"/>" << METAIO_STREAM::endl;
-        file << " </componentAction>" << METAIO_STREAM::endl;
-        file << METAIO_STREAM::endl;
+             << datapath.c_str() << "\"/>" << std::endl;
+        file << " </componentAction>" << std::endl;
+        file << std::endl;
         order++;
         }
       ++itFields;
@@ -1536,9 +1536,9 @@ ExportGAD(bool dynamic)
     }
 
   file << " <componentAction type=\"JobSubmission\" order=\"" << order << "\">"
-       << METAIO_STREAM::endl;
+       << std::endl;
   file << "  <parameter name=\"Executable\" value=\""
-       << m_ExecutableName.c_str() << "\"/>" << METAIO_STREAM::endl;
+       << m_ExecutableName.c_str() << "\"/>" << std::endl;
   file << "  <parameter name=\"Arguments\"  value=\"";
   // Write out the command line arguments
   it = options.begin();
@@ -1551,14 +1551,14 @@ ExportGAD(bool dynamic)
     file << "{" << (*it).name.c_str() << "}";
     ++it;
     }
-  file << "\"/>" << METAIO_STREAM::endl;
+  file << "\"/>" << std::endl;
   // Write out the arguments that are not data
   it = options.begin();
   while(it != options.end())
     {
     // Find if this is a non data field
     bool isData = false;
-    METAIO_STL::vector<Field>::const_iterator itFields = (*it).fields.begin();
+    std::vector<Field>::const_iterator itFields = (*it).fields.begin();
     while(itFields != (*it).fields.end())
       {
       if((*itFields).externaldata != DATA_NONE)
@@ -1610,7 +1610,7 @@ ExportGAD(bool dynamic)
         }
       }
 
-    file << ">" << METAIO_STREAM::endl;
+    file << ">" << std::endl;
 
     // Now writes the value of the arguments
     itFields = (*it).fields.begin();
@@ -1631,39 +1631,39 @@ ExportGAD(bool dynamic)
         {
         file << " rangeMax=\"" << (*itFields).rangeMax.c_str() << "\"";
         }
-      file << "/>" << METAIO_STREAM::endl;
+      file << "/>" << std::endl;
       ++itFields;
       }
-    file << "  </group>" << METAIO_STREAM::endl;
+    file << "  </group>" << std::endl;
     ++it;
     }
-  file << " </componentAction>" << METAIO_STREAM::endl;
+  file << " </componentAction>" << std::endl;
   order++;
-  file << METAIO_STREAM::endl;
+  file << std::endl;
   // Write out the input data to be transferred
   it = options.begin();
   while(it != options.end())
     {
-    METAIO_STL::vector<Field>::const_iterator itFields = (*it).fields.begin();
+    std::vector<Field>::const_iterator itFields = (*it).fields.begin();
     while(itFields != (*it).fields.end())
       {
       if((*itFields).externaldata == DATA_OUT)
         {
         file << " <componentAction type=\"DataRelocation\" order=\"" << order
-             << "\">" << METAIO_STREAM::endl;
+             << "\">" << std::endl;
         file << "  <parameter name=\"Name\" Value=\""
              << (*itFields).name.c_str()
-             <<"\"/>" << METAIO_STREAM::endl;
+             <<"\"/>" << std::endl;
         file << "  <parameter name=\"Host\" Value=\"hostname\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"Description\" value=\""
              << (*itFields).description.c_str() << "\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"Direction\" value=\"Out\"/>"
-             << METAIO_STREAM::endl;
+             << std::endl;
         file << "  <parameter name=\"Protocol\" value=\"gsiftp\"/>"
-             << METAIO_STREAM::endl;
-        METAIO_STL::string datapath = (*itFields).value;
+             << std::endl;
+        std::string datapath = (*itFields).value;
         long int slash = static_cast<long int>(datapath.find_last_of('/'));
         if(slash>0)
           {
@@ -1675,24 +1675,24 @@ ExportGAD(bool dynamic)
           datapath = datapath.substr(slash+1,datapath.size()-slash-1);
           }
         file << "  <parameter name=\"SourceDataPath\" value=\""
-             << datapath.c_str() << "\"/>" << METAIO_STREAM::endl;
+             << datapath.c_str() << "\"/>" << std::endl;
         file << "  <parameter name=\"DestDataPath\" value=\""
-             << (*itFields).value.c_str() << "\"/>" << METAIO_STREAM::endl;
-        file << " </componentAction>" << METAIO_STREAM::endl;
-        file << METAIO_STREAM::endl;
+             << (*itFields).value.c_str() << "\"/>" << std::endl;
+        file << " </componentAction>" << std::endl;
+        file << std::endl;
         order++;
         }
       ++itFields;
       }
     ++it;
     }
-  file << "    </componentActionList>" << METAIO_STREAM::endl;
-  file << "  </applicationComponent>" << METAIO_STREAM::endl;
-  file << "</gridApplication>" << METAIO_STREAM::endl;
+  file << "    </componentActionList>" << std::endl;
+  file << "  </applicationComponent>" << std::endl;
+  file << "</gridApplication>" << std::endl;
 
   file.close();
 
-  METAIO_STREAM::cout << "done" << METAIO_STREAM::endl;
+  std::cout << "done" << std::endl;
   return true;
 }
 
@@ -1719,8 +1719,8 @@ bool MetaCommand::Parse(int argc, char* argv[])
   // Fill in the results
   m_ParsedOptionVector.clear();
   bool inArgument = false;
-  METAIO_STL::string tag = "";
-  METAIO_STL::string args;
+  std::string tag = "";
+  std::string args;
 
   unsigned int currentField = 0; // current field position
   int currentOption = 0; // id of the option to fill
@@ -1728,21 +1728,21 @@ bool MetaCommand::Parse(int argc, char* argv[])
   unsigned int optionalValuesRemaining=0;
   bool isComplete = false; // check if the option should be parse until
                            // the next tag is found
-  METAIO_STL::string completeString = "";
+  std::string completeString = "";
 
   bool exportGAD = false;
   for(unsigned int i=1;i<(unsigned int)argc;i++)
     {
     if(!strcmp(argv[i],"-V") || !strcmp(argv[i],"-H"))
       {
-      METAIO_STREAM::cout << "Usage : " << argv[0] << METAIO_STREAM::endl;
+      std::cout << "Usage : " << argv[0] << std::endl;
       this->ListOptions();
       return true;
       }
     // List the options if using -v
     if(!strcmp(argv[i],"-v") || !strcmp(argv[i],"-h"))
       {
-      METAIO_STREAM::cout << "Usage : " << argv[0] << METAIO_STREAM::endl;
+      std::cout << "Usage : " << argv[0] << std::endl;
       this->ListOptionsSimplified();
       return true;
       }
@@ -1751,8 +1751,8 @@ bool MetaCommand::Parse(int argc, char* argv[])
       {
       if((i+1)>=(unsigned int)argc)
         {
-        METAIO_STREAM::cout << "--loadArguments expected a filename as argument"
-                            << METAIO_STREAM::endl;
+        std::cout << "--loadArguments expected a filename as argument"
+                            << std::endl;
         return false;
         }
       this->LoadArgumentsFromXML(argv[i+1]);
@@ -1777,14 +1777,14 @@ bool MetaCommand::Parse(int argc, char* argv[])
       }
     if(!strcmp(argv[i],"-version"))
       {
-      METAIO_STREAM::cout << "Version: " << m_Version.c_str()
-                          << METAIO_STREAM::endl;
+      std::cout << "Version: " << m_Version.c_str()
+                          << std::endl;
       continue;
       }
     if(!strcmp(argv[i],"-date"))
       {
-      METAIO_STREAM::cout << "Date: " << m_Date.c_str()
-                          << METAIO_STREAM::endl;
+      std::cout << "Date: " << m_Date.c_str()
+                          << std::endl;
       continue;
       }
     if(!strcmp(argv[i],"-exportGAD")
@@ -1812,9 +1812,9 @@ bool MetaCommand::Parse(int argc, char* argv[])
             }
           else
             {
-            METAIO_STREAM::cout << "Found tag " << argv[i]
+            std::cout << "Found tag " << argv[i]
                               << " before end of value list!"
-                              << METAIO_STREAM::endl;
+                              << std::endl;
             return false;
             }
           }
@@ -1838,7 +1838,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
 
         // We check the number of mandatory and optional values for
         // this tag
-        METAIO_STL::vector<Field>::const_iterator fIt =
+        std::vector<Field>::const_iterator fIt =
                                  this->GetOptionByMinusTag(tag)->fields.begin();
         while(fIt != this->GetOptionByMinusTag(tag)->fields.end())
           {
@@ -1853,9 +1853,9 @@ bool MetaCommand::Parse(int argc, char* argv[])
 
         if(currentOption < 0)
           {
-          METAIO_STREAM::cout << "Error processing tag " << tag.c_str()
+          std::cout << "Error processing tag " << tag.c_str()
                               << ".  Tag exists but cannot find its Id."
-                              << METAIO_STREAM::endl;
+                              << std::endl;
           }
         else
           {
@@ -1890,9 +1890,9 @@ bool MetaCommand::Parse(int argc, char* argv[])
         {
         if(m_Verbose)
           {
-          METAIO_STREAM::cout << "The tag " << tag.c_str()
+          std::cout << "The tag " << tag.c_str()
                               << " is not a valid argument : skipping this tag"
-                              << METAIO_STREAM::endl;
+                              << std::endl;
           }
         if(m_FailOnUnrecognizedOption)
           {
@@ -1925,10 +1925,10 @@ bool MetaCommand::Parse(int argc, char* argv[])
 
       if(!found && m_Verbose)
         {
-        METAIO_STREAM::cout
+        std::cout
                   << "Too many arguments specified in your command line! "
                   << "Skipping extra argument: " << argv[i]
-                  << METAIO_STREAM::endl;
+                  << std::endl;
         }
 
       inArgument=true;
@@ -1967,10 +1967,10 @@ bool MetaCommand::Parse(int argc, char* argv[])
         // We change the value only if this is not a tag
         if(this->OptionExistsByMinusTag(argv[i]))
           {
-          METAIO_STREAM::cout << "Option "
+          std::cout << "Option "
                               << m_OptionVector[currentOption].name.c_str()
                               << " expect a value and got tag: " << argv[i]
-                              << METAIO_STREAM::endl;
+                              << std::endl;
           this->ListOptionsSimplified(false);
           return false;
           }
@@ -2030,10 +2030,10 @@ bool MetaCommand::Parse(int argc, char* argv[])
 
   if(valuesRemaining>0)
     {
-    METAIO_STREAM::cout << "Not enough parameters for "
+    std::cout << "Not enough parameters for "
                         << m_OptionVector[currentOption].name.c_str()
-                        << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "Usage: " << argv[0] << METAIO_STREAM::endl;
+                        << std::endl;
+    std::cout << "Usage: " << argv[0] << std::endl;
     this->ListOptionsSimplified(false);
     return false;
     }
@@ -2048,16 +2048,16 @@ bool MetaCommand::Parse(int argc, char* argv[])
       // First check if the option is actually defined
       if(!(*it).userDefined)
         {
-        METAIO_STREAM::cout << "Option " << (*it).name.c_str()
+        std::cout << "Option " << (*it).name.c_str()
                             << " is required but not defined"
-                            << METAIO_STREAM::endl;
+                            << std::endl;
         requiredAndNotDefined = true;
         ++it;
         continue;
         }
 
       // Check if the values are defined
-      METAIO_STL::vector<Field>::const_iterator itFields = (*it).fields.begin();
+      std::vector<Field>::const_iterator itFields = (*it).fields.begin();
       bool defined = true;
       while(itFields != (*it).fields.end())
         {
@@ -2072,15 +2072,15 @@ bool MetaCommand::Parse(int argc, char* argv[])
         {
         if((*it).tag.size()>0 || (*it).longtag.size()>0)
           {
-          METAIO_STREAM::cout << "Field " << (*it).tag.c_str()
+          std::cout << "Field " << (*it).tag.c_str()
                               << " is required but not defined"
-                              << METAIO_STREAM::endl;
+                              << std::endl;
           }
         else
           {
-          METAIO_STREAM::cout << "Field " << (*it).name.c_str()
+          std::cout << "Field " << (*it).name.c_str()
                               << " is required but not defined"
-                              << METAIO_STREAM::endl;
+                              << std::endl;
           }
         requiredAndNotDefined = true;
         }
@@ -2090,7 +2090,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
 
   if(requiredAndNotDefined)
     {
-    //METAIO_STREAM::cout << "Command: " << argv[0] << METAIO_STREAM::endl;
+    //std::cout << "Command: " << argv[0] << std::endl;
     this->ListOptionsSimplified(false);
     return false;
     }
@@ -2100,7 +2100,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
   bool valueInRange = true;
   while(itParsed != m_ParsedOptionVector.end())
     {
-    METAIO_STL::vector<Field>::const_iterator itFields = (*itParsed).fields
+    std::vector<Field>::const_iterator itFields = (*itParsed).fields
                                                                     .begin();
     while(itFields != (*itParsed).fields.end())
       {
@@ -2122,12 +2122,12 @@ bool MetaCommand::Parse(int argc, char* argv[])
               < atof((*itFields).value.c_str())))
           )
           {
-          METAIO_STREAM::cout << (*itParsed).name.c_str()
+          std::cout << (*itParsed).name.c_str()
                     << "." << (*itFields).name.c_str()
                     << " : Value (" << (*itFields).value.c_str() << ") "
                     << "is not in the range [" << (*itFields).rangeMin.c_str()
                     << "," << (*itFields).rangeMax.c_str()
-                    << "]" << METAIO_STREAM::endl;
+                    << "]" << std::endl;
           valueInRange = false;
           }
         }
@@ -2152,7 +2152,7 @@ bool MetaCommand::Parse(int argc, char* argv[])
 }
 
 /** Return the string representation of a type */
-METAIO_STL::string MetaCommand::TypeToString(TypeEnumType type)
+std::string MetaCommand::TypeToString(TypeEnumType type)
 {
   switch(type)
     {
@@ -2228,8 +2228,8 @@ MetaCommand::TypeEnumType MetaCommand::StringToType(const char* type)
 
 
 /** Set the long flag for the option */
-bool MetaCommand::SetOptionLongTag(METAIO_STL::string optionName,
-                                    METAIO_STL::string longTag)
+bool MetaCommand::SetOptionLongTag(std::string optionName,
+                                    std::string longTag)
 {
   OptionVector::iterator itOption = m_OptionVector.begin();
   while(itOption != m_OptionVector.end())
@@ -2246,8 +2246,8 @@ bool MetaCommand::SetOptionLongTag(METAIO_STL::string optionName,
 }
 
 /** Set the label for the option */
-bool MetaCommand::SetOptionLabel(METAIO_STL::string optionName,
-                                 METAIO_STL::string label)
+bool MetaCommand::SetOptionLabel(std::string optionName,
+                                 std::string label)
 {
   OptionVector::iterator itOption = m_OptionVector.begin();
   while(itOption != m_OptionVector.end())
@@ -2265,9 +2265,9 @@ bool MetaCommand::SetOptionLabel(METAIO_STL::string optionName,
 
 /** Set the group for a field or an option
  *  If the group doesn't exist it is automatically created. */
-bool MetaCommand::SetParameterGroup(METAIO_STL::string optionName,
-                                    METAIO_STL::string groupName,
-                                    METAIO_STL::string groupDescription,
+bool MetaCommand::SetParameterGroup(std::string optionName,
+                                    std::string groupName,
+                                    std::string groupDescription,
                                     bool advanced
                                     )
 {
@@ -2299,8 +2299,8 @@ bool MetaCommand::SetParameterGroup(METAIO_STL::string optionName,
 
   if(!optionExists)
     {
-    METAIO_STREAM::cout << "The option " << optionName.c_str()
-                        << " doesn't exist" << METAIO_STREAM::endl;
+    std::cout << "The option " << optionName.c_str()
+                        << " doesn't exist" << std::endl;
     return false;
     }
 
@@ -2332,7 +2332,7 @@ bool MetaCommand::LoadArgumentsFromXML(const char* filename,
 
   if (doc == NULL )
     {
-    METAIO_STREAM::cerr << "Cannot parse XML file" << METAIO_STREAM::endl;
+    std::cerr << "Cannot parse XML file" << std::endl;
     return false;
     }
 
@@ -2340,13 +2340,13 @@ bool MetaCommand::LoadArgumentsFromXML(const char* filename,
 
   if (cur == NULL)
     {
-    METAIO_STREAM::cerr << "XML document is empty" << METAIO_STREAM::endl;
+    std::cerr << "XML document is empty" << std::endl;
     xmlFreeDoc(doc);
     return false;
     }
   if (xmlStrcmp(cur->name, (const xmlChar *) "MetaCommand"))
     {
-    METAIO_STREAM::cerr << "document of the wrong type. Root node should be MetaCommand" << METAIO_STREAM::endl;
+    std::cerr << "document of the wrong type. Root node should be MetaCommand" << std::endl;
     xmlFreeDoc(doc);
     return false;
     }
@@ -2386,7 +2386,7 @@ bool MetaCommand::LoadArgumentsFromXML(const char* filename,
     }
   xmlFreeDoc(doc);
 #else
-  METAIO_STREAM::cout << "LoadArguments(" << filename << ") requires libxml2" << METAIO_STREAM::endl;
+  std::cout << "LoadArguments(" << filename << ") requires libxml2" << std::endl;
   if(createMissingArguments)
     {
     }
@@ -2409,8 +2409,8 @@ bool MetaCommand::SetOptionValue(const char* optionName,
     if((*it).name == optionName)
       {
       (*it).userDefined = true;
-      METAIO_STL::vector<Field> & fields = (*it).fields;
-      METAIO_STL::vector<Field>::iterator itField = fields.begin();
+      std::vector<Field> & fields = (*it).fields;
+      std::vector<Field>::iterator itField = fields.begin();
       while(itField != fields.end())
         {
         if((*itField).name == name)

--- a/src/metaCommand.h
+++ b/src/metaCommand.h
@@ -39,137 +39,137 @@ public:
   typedef enum {INT,FLOAT,CHAR,STRING,LIST,FLAG,BOOL,IMAGE,ENUM,FILE} TypeEnumType;
 
   struct Field{
-    METAIO_STL::string  name;
-    METAIO_STL::string  description;
-    METAIO_STL::string  value;
+    std::string  name;
+    std::string  description;
+    std::string  value;
     TypeEnumType        type;
     DataEnumType        externaldata;
-    METAIO_STL::string  rangeMin;
-    METAIO_STL::string  rangeMax;
+    std::string  rangeMin;
+    std::string  rangeMax;
     bool                required;
     bool                userDefined;
     };
 
   struct Option{
-    METAIO_STL::string        name;
-    METAIO_STL::string        description;
-    METAIO_STL::string        tag;
-    METAIO_STL::string        longtag;
-    METAIO_STL::string        label;
-    METAIO_STL::vector<Field> fields;
+    std::string        name;
+    std::string        description;
+    std::string        tag;
+    std::string        longtag;
+    std::string        label;
+    std::vector<Field> fields;
     bool                      required;
     bool                      userDefined;
     bool                      complete;
   };
 
   struct ParameterGroup{
-    METAIO_STL::string                     name;
-    METAIO_STL::string                     description;
-    METAIO_STL::vector<METAIO_STL::string> options;
+    std::string                     name;
+    std::string                     description;
+    std::vector<std::string> options;
     bool                                   advanced;
     };
 
-  typedef METAIO_STL::vector<Option>             OptionVector;
-  typedef METAIO_STL::vector<ParameterGroup>     ParameterGroupVector;
+  typedef std::vector<Option>             OptionVector;
+  typedef std::vector<ParameterGroup>     ParameterGroupVector;
 
   MetaCommand();
   ~MetaCommand() {}
 
   bool SetOption(Option option);
-  bool SetOption(METAIO_STL::string name,
-                 METAIO_STL::string tag,
+  bool SetOption(std::string name,
+                 std::string tag,
                  bool required,
-                 METAIO_STL::string description,
-                 METAIO_STL::vector<Field> fields);
-  bool SetOption(METAIO_STL::string name,
-                 METAIO_STL::string tag,
+                 std::string description,
+                 std::vector<Field> fields);
+  bool SetOption(std::string name,
+                 std::string tag,
                  bool required,
-                 METAIO_STL::string description,
+                 std::string description,
                  TypeEnumType type = FLAG,
-                 METAIO_STL::string defVal = "",
+                 std::string defVal = "",
                  DataEnumType externalData = DATA_NONE);
 
   /** Fields are added in order */
-  bool AddField(METAIO_STL::string name,
-                METAIO_STL::string description,
+  bool AddField(std::string name,
+                std::string description,
                 TypeEnumType type,
                 DataEnumType externalData = DATA_NONE,
-                METAIO_STL::string rangeMin = "",
-                METAIO_STL::string rangeMax = ""
+                std::string rangeMin = "",
+                std::string rangeMax = ""
                 );
 
   /** For backward compatibility */
-  bool AddField(METAIO_STL::string name,
-                METAIO_STL::string description,
+  bool AddField(std::string name,
+                std::string description,
                 TypeEnumType type,
                 bool externalData );
 
   /** Add a field to an option */
-  bool AddOptionField(METAIO_STL::string optionName,
-                      METAIO_STL::string name,
+  bool AddOptionField(std::string optionName,
+                      std::string name,
                       TypeEnumType type,
                       bool required=true,
-                      METAIO_STL::string defVal = "",
-                      METAIO_STL::string description = "",
+                      std::string defVal = "",
+                      std::string description = "",
                       DataEnumType externalData = DATA_NONE);
 
   /** Set the range of value as an option */
-  bool SetOptionRange(METAIO_STL::string optionName,
-                      METAIO_STL::string name,
-                      METAIO_STL::string rangeMin,
-                      METAIO_STL::string rangeMax);
+  bool SetOptionRange(std::string optionName,
+                      std::string name,
+                      std::string rangeMin,
+                      std::string rangeMax);
 
   /** Set the list of values that can be used with an option */
-  bool SetOptionEnumerations(METAIO_STL::string optionName,
-                             METAIO_STL::string name,
-                             METAIO_STL::string optionEnums);
+  bool SetOptionEnumerations(std::string optionName,
+                             std::string name,
+                             std::string optionEnums);
 
   /** Set the long tag for the option */
-  bool SetOptionLongTag(METAIO_STL::string optionName,
-                        METAIO_STL::string longTag);
+  bool SetOptionLongTag(std::string optionName,
+                        std::string longTag);
 
   /** Set the label for the option */
-  bool SetOptionLabel(METAIO_STL::string optionName,
-                      METAIO_STL::string label);
+  bool SetOptionLabel(std::string optionName,
+                      std::string label);
 
   /** Set the group for a field or an option
    *  If the group doesn't exist it is automatically created. */
-  bool SetParameterGroup(METAIO_STL::string optionName,
-                         METAIO_STL::string groupName,
-                         METAIO_STL::string groupDescription="",
+  bool SetParameterGroup(std::string optionName,
+                         std::string groupName,
+                         std::string groupDescription="",
                          bool advanced=false);
 
   /** Collect all the information until the next tag
    * \warning this function works only if the field is of type String */
-  void SetOptionComplete(METAIO_STL::string optionName,
+  void SetOptionComplete(std::string optionName,
                          bool complete);
 
   /** Get the values given the option name */
-  bool GetValueAsBool(METAIO_STL::string optionName,
-                      METAIO_STL::string fieldName="");
+  bool GetValueAsBool(std::string optionName,
+                      std::string fieldName="");
   bool GetValueAsBool(Option option,
-                      METAIO_STL::string fieldName="");
+                      std::string fieldName="");
 
-  float GetValueAsFloat(METAIO_STL::string optionName,
-                        METAIO_STL::string fieldName="");
+  float GetValueAsFloat(std::string optionName,
+                        std::string fieldName="");
   float GetValueAsFloat(Option option,
-                        METAIO_STL::string fieldName="");
+                        std::string fieldName="");
 
-  int GetValueAsInt(METAIO_STL::string optionName,
-                    METAIO_STL::string fieldName="");
+  int GetValueAsInt(std::string optionName,
+                    std::string fieldName="");
   int GetValueAsInt(Option option,
-                    METAIO_STL::string fieldName="");
+                    std::string fieldName="");
 
-  METAIO_STL::string GetValueAsString(METAIO_STL::string optionName,
-                                      METAIO_STL::string fieldName="");
-  METAIO_STL::string GetValueAsString(Option option,
-                                      METAIO_STL::string fieldName="");
+  std::string GetValueAsString(std::string optionName,
+                                      std::string fieldName="");
+  std::string GetValueAsString(Option option,
+                                      std::string fieldName="");
 
-  METAIO_STL::list< METAIO_STL::string > GetValueAsList(
-                                            METAIO_STL::string optionName);
-  METAIO_STL::list< METAIO_STL::string > GetValueAsList(Option option);
+  std::list< std::string > GetValueAsList(
+                                            std::string optionName);
+  std::list< std::string > GetValueAsList(Option option);
 
-  bool GetOptionWasSet(METAIO_STL::string optionName);
+  bool GetOptionWasSet(std::string optionName);
   bool GetOptionWasSet(Option option);
 
   /** List the options */
@@ -178,10 +178,10 @@ public:
   void ListOptionsSlicerXML();
   void ListOptionsSimplified(bool extended=true);
 
-  Option * GetOptionByMinusTag(METAIO_STL::string minusTag);
-  Option * GetOptionByTag(METAIO_STL::string minusTag);
+  Option * GetOptionByMinusTag(std::string minusTag);
+  Option * GetOptionByTag(std::string minusTag);
 
-  bool OptionExistsByMinusTag(METAIO_STL::string minusTag);
+  bool OptionExistsByMinusTag(std::string minusTag);
 
   bool Parse(int argc, char* argv[]);
 
@@ -193,26 +193,26 @@ public:
   bool ExportGAD(bool dynamic=false);
 
   /** Extract the date from cvs date */
-  METAIO_STL::string ExtractDateFromCVS(METAIO_STL::string date);
-  void               SetDateFromCVS(METAIO_STL::string date);
+  std::string ExtractDateFromCVS(std::string date);
+  void               SetDateFromCVS(std::string date);
 
   /** Extract the version from cvs date */
-  METAIO_STL::string ExtractVersionFromCVS(METAIO_STL::string version);
-  void               SetVersionFromCVS(METAIO_STL::string version);
+  std::string ExtractVersionFromCVS(std::string version);
+  void               SetVersionFromCVS(std::string version);
 
   /** Set the version of the app */
-  METAIO_STL::string GetVersion()
+  std::string GetVersion()
     { return m_Version; }
 
   void SetVersion(const char* version)
     { m_Version=version; }
 
   /** Get the name of the application */
-  METAIO_STL::string GetApplicationName()
+  std::string GetApplicationName()
     { return m_ExecutableName; }
 
   /** Set the date of the app */
-  METAIO_STL::string GetDate()
+  std::string GetDate()
     { return m_Date; }
 
   void SetDate(const char* date)
@@ -224,25 +224,25 @@ public:
   /** Set the description */
   void SetDescription(const char* description)
     { m_Description=description; }
-  METAIO_STL::string GetDescription() const
+  std::string GetDescription() const
     {return m_Description;}
 
   /** Set the author */
   void SetAuthor(const char* author)
     { m_Author=author; }
-  METAIO_STL::string GetAuthor() const
+  std::string GetAuthor() const
     {return m_Author;}
 
   /** Set the acknowledgments */
   void SetAcknowledgments(const char* acknowledgments)
     { m_Acknowledgments=acknowledgments; }
-  METAIO_STL::string GetAcknowledgments() const
+  std::string GetAcknowledgments() const
     {return m_Acknowledgments;}
 
   /** Set the category */
   void SetCategory(const char* category)
     { m_Category=category; }
-  METAIO_STL::string GetCategory() const
+  std::string GetCategory() const
     {return m_Category;}
 
   long GetOptionId(Option* option);
@@ -258,7 +258,7 @@ public:
   void SetHelpCallBack(void (* newHelpCallBack)(void))
     { m_HelpCallBack = newHelpCallBack; }
 
-  METAIO_STL::string TypeToString(TypeEnumType type);
+  std::string TypeToString(TypeEnumType type);
   TypeEnumType StringToType(const char* type);
 
   void SetVerbose(bool verbose) {m_Verbose = verbose;}
@@ -284,18 +284,18 @@ public:
 protected:
 
   /** Small XML helper */
-  METAIO_STL::string GetXML(const char* buffer,
+  std::string GetXML(const char* buffer,
                             const char* desc,
                             unsigned long pos);
 
-  METAIO_STL::string m_Version;
-  METAIO_STL::string m_Date;
-  METAIO_STL::string m_Name;
-  METAIO_STL::string m_Description;
-  METAIO_STL::string m_Author;
-  METAIO_STL::string m_ExecutableName;
-  METAIO_STL::string m_Acknowledgments;
-  METAIO_STL::string m_Category;
+  std::string m_Version;
+  std::string m_Date;
+  std::string m_Name;
+  std::string m_Description;
+  std::string m_Author;
+  std::string m_ExecutableName;
+  std::string m_Acknowledgments;
+  std::string m_Category;
 
   ParameterGroupVector m_ParameterGroup;
 
@@ -321,7 +321,7 @@ private:
   bool         m_DisableDeprecatedWarnings;
 
   // Use when write --xml
-  void WriteXMLOptionToCout(METAIO_STL::string optionName,unsigned int& index);
+  void WriteXMLOptionToCout(std::string optionName,unsigned int& index);
 
 }; // end of class
 

--- a/src/metaContour.cxx
+++ b/src/metaContour.cxx
@@ -59,7 +59,7 @@ MetaContour::
 MetaContour()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaContour()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaContour()" << std::endl;
   Clear();
 }
 
@@ -68,7 +68,7 @@ MetaContour::
 MetaContour(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaContour()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaContour()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -78,7 +78,7 @@ MetaContour::
 MetaContour(const MetaContour *_Contour)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaContour()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaContour()" << std::endl;
   Clear();
   CopyInfo(_Contour);
 }
@@ -90,7 +90,7 @@ MetaContour::
 MetaContour(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaContour()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaContour()" << std::endl;
   Clear();
 }
 
@@ -107,12 +107,12 @@ void MetaContour::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "ControlPointDim = " << m_ControlPointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NControlPoints = " << m_NControlPoints << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "InterpolatedPointDim = " << m_InterpolatedPointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NInterpolatedPoints = " << m_NInterpolatedPoints << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Display Orientation = " << m_DisplayOrientation << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Attached to Slice = " << m_AttachedToSlice << METAIO_STREAM::endl;
+  std::cout << "ControlPointDim = " << m_ControlPointDim << std::endl;
+  std::cout << "NControlPoints = " << m_NControlPoints << std::endl;
+  std::cout << "InterpolatedPointDim = " << m_InterpolatedPointDim << std::endl;
+  std::cout << "NInterpolatedPoints = " << m_NInterpolatedPoints << std::endl;
+  std::cout << "Display Orientation = " << m_DisplayOrientation << std::endl;
+  std::cout << "Attached to Slice = " << m_AttachedToSlice << std::endl;
 }
 
 void MetaContour::
@@ -189,7 +189,7 @@ Clear()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaContour: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaContour: Clear" << std::endl;
     }
   MetaObject::Clear();
   m_InterpolationType = MET_NO_INTERPOLATION;
@@ -265,7 +265,7 @@ DisplayOrientation() const
 void MetaContour::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaContour: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaContour: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -300,7 +300,7 @@ M_SetupReadFields()
 void MetaContour::
 M_SetupWriteFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaContour: M_SetupWriteFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaContour: M_SetupWriteFields" << std::endl;
 
   strcpy(m_ObjectTypeName,"Contour");
   MetaObject::M_SetupWriteFields();
@@ -347,15 +347,15 @@ M_SetupWriteFields()
 bool MetaContour::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaContour: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaContour: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaContour: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaContour: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaContour: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaContour: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 
@@ -419,10 +419,10 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
       {
-      METAIO_STREAM::cout << "MetaContour: m_Read: data not read completely"
-                          << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaContour: m_Read: data not read completely"
+                          << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc
+                          << std::endl;
       delete [] _data;
       return false;
       }
@@ -621,10 +621,10 @@ M_Read()
       int gc = static_cast<int>(m_ReadStream->gcount());
       if(gc != readSize)
         {
-        METAIO_STREAM::cout << "MetaContour: m_Read: data not read completely"
-                            << METAIO_STREAM::endl;
-        METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc
-                            << METAIO_STREAM::endl;
+        std::cout << "MetaContour: m_Read: data not read completely"
+                            << std::endl;
+        std::cout << "   ideal = " << readSize << " : actual = " << gc
+                            << std::endl;
         delete [] _data;
         return false;
         }
@@ -732,13 +732,13 @@ M_Write()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaContour: M_Write" << METAIO_STREAM::endl;
+    std::cout << "MetaContour: M_Write" << std::endl;
     }
 
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaContour: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaContour: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
@@ -820,7 +820,7 @@ M_Write()
         {
         *m_WriteStream << (*it)->m_Color[d] << " ";
         }
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }
@@ -913,7 +913,7 @@ M_Write()
         {
         *m_WriteStream << (*it)->m_Color[d] << " ";
         }
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }

--- a/src/metaContour.h
+++ b/src/metaContour.h
@@ -86,8 +86,8 @@ class METAIO_EXPORT MetaContour : public MetaObject
 
 public:
 
- typedef METAIO_STL::list<ContourControlPnt*> ControlPointListType;
- typedef METAIO_STL::list<ContourInterpolatedPnt*> InterpolatedPointListType;
+ typedef std::list<ContourControlPnt*> ControlPointListType;
+ typedef std::list<ContourInterpolatedPnt*> InterpolatedPointListType;
 
  MetaContour(void);
  MetaContour(const char *_headerName);

--- a/src/metaDTITube.cxx
+++ b/src/metaDTITube.cxx
@@ -92,7 +92,7 @@ MetaDTITube::
 MetaDTITube()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaDTITube()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaDTITube()" << std::endl;
   Clear();
 }
 
@@ -101,7 +101,7 @@ MetaDTITube::
 MetaDTITube(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaDTITube()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaDTITube()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -111,7 +111,7 @@ MetaDTITube::
 MetaDTITube(const MetaDTITube *_DTITube)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaDTITube()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaDTITube()" << std::endl;
   Clear();
   CopyInfo(_DTITube);
 }
@@ -121,7 +121,7 @@ MetaDTITube::
 MetaDTITube(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaDTITube()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaDTITube()" << std::endl;
   Clear();
 }
 
@@ -146,21 +146,21 @@ void MetaDTITube::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "ParentPoint = " << m_ParentPoint << METAIO_STREAM::endl;
+  std::cout << "ParentPoint = " << m_ParentPoint << std::endl;
   if(m_Root)
     {
-    METAIO_STREAM::cout << "Root = " << "True" << METAIO_STREAM::endl;
+    std::cout << "Root = " << "True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "Root = " << "True" << METAIO_STREAM::endl;
+    std::cout << "Root = " << "True" << std::endl;
     }
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim.c_str()
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim.c_str()
+                      << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaDTITube::
@@ -224,7 +224,7 @@ ParentPoint() const
 void MetaDTITube::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaDTITube: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaDTITube: Clear" << std::endl;
   MetaObject::Clear();
   // Delete the list of pointers to DTITubes.
   PointListType::iterator it = m_PointList.begin();
@@ -254,7 +254,7 @@ M_Destroy()
 void MetaDTITube::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaDTITube: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaDTITube: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -351,8 +351,8 @@ M_SetupWriteFields()
 /** Return the position given the name of the field */
 int MetaDTITube::GetPosition(const char* name) const
 {
-  METAIO_STL::vector<PositionType>::const_iterator it = m_Positions.begin();
-  METAIO_STL::vector<PositionType>::const_iterator itEnd = m_Positions.end();
+  std::vector<PositionType>::const_iterator it = m_Positions.begin();
+  std::vector<PositionType>::const_iterator itEnd = m_Positions.end();
   while(it != itEnd)
     {
     if(!strcmp((*it).first.c_str(),name))
@@ -370,18 +370,18 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaDTITube: M_Read: Loading Header" << METAIO_STREAM::endl;
+    std::cout << "MetaDTITube: M_Read: Loading Header" << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaDTITube: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaDTITube: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaDTITube: M_Read: Parsing Header" << METAIO_STREAM::endl;
+    std::cout << "MetaDTITube: M_Read: Parsing Header" << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -436,7 +436,7 @@ M_Read()
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaDTITube: Parsing point dim" << METAIO_STREAM::endl;
+    std::cout << "MetaDTITube: Parsing point dim" << std::endl;
     }
 
   int j;
@@ -472,10 +472,10 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
       {
-      METAIO_STREAM::cout << "MetaLine: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize
-                << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaLine: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize
+                << " : actual = " << gc << std::endl;
       delete [] _data;
       return false;
       }
@@ -513,9 +513,9 @@ M_Read()
         pnt->m_TensorMatrix[d] = (float)td;
         }
 
-      METAIO_STL::vector<PositionType>::const_iterator itFields =
+      std::vector<PositionType>::const_iterator itFields =
                                                            m_Positions.begin();
-      METAIO_STL::vector<PositionType>::const_iterator itFieldsEnd =
+      std::vector<PositionType>::const_iterator itFieldsEnd =
                                                            m_Positions.end();
       while(itFields !=  itFieldsEnd)
         {
@@ -568,13 +568,13 @@ M_Read()
 
       if( positionOfX < 0 )
         {
-        METAIO_STREAM::cerr << "MetaDTITube: M_Read: 'x' not found." << METAIO_STREAM::endl;
+        std::cerr << "MetaDTITube: M_Read: 'x' not found." << std::endl;
         return false;
         }
 
       if( positionOfY < 0 )
         {
-        METAIO_STREAM::cerr << "MetaDTITube: M_Read: 'y' not found." << METAIO_STREAM::endl;
+        std::cerr << "MetaDTITube: M_Read: 'y' not found." << std::endl;
         return false;
         }
 
@@ -588,7 +588,7 @@ M_Read()
 
         if( positionOfZ < 0 )
           {
-          METAIO_STREAM::cerr << "MetaDTITube: M_Read: 'z' not found." << METAIO_STREAM::endl;
+          std::cerr << "MetaDTITube: M_Read: 'z' not found." << std::endl;
           delete pnt;
           return false;
           }
@@ -634,9 +634,9 @@ M_Read()
         }
 
       // Add the extrafields
-      METAIO_STL::vector<PositionType>::const_iterator itFields =
+      std::vector<PositionType>::const_iterator itFields =
                                                            m_Positions.begin();
-      METAIO_STL::vector<PositionType>::const_iterator itFieldsEnd =
+      std::vector<PositionType>::const_iterator itFieldsEnd =
                                                            m_Positions.end();
       while(itFields != itFieldsEnd)
         {
@@ -693,7 +693,7 @@ M_Write()
 
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaDTITube: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaDTITube: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
@@ -776,7 +776,7 @@ M_Write()
         ++itFields;
         }
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }

--- a/src/metaDTITube.h
+++ b/src/metaDTITube.h
@@ -45,8 +45,8 @@ class METAIO_EXPORT DTITubePnt
 {
 public:
 
-  typedef METAIO_STL::pair<METAIO_STL::string,float>  FieldType;
-  typedef METAIO_STL::vector<FieldType>        FieldListType;
+  typedef std::pair<std::string,float>  FieldType;
+  typedef std::vector<FieldType>        FieldListType;
 
   DTITubePnt(int dim);
 
@@ -78,8 +78,8 @@ class METAIO_EXPORT MetaDTITube : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<DTITubePnt*> PointListType;
-   typedef METAIO_STL::pair<METAIO_STL::string,unsigned int> PositionType;
+   typedef std::list<DTITubePnt*> PointListType;
+   typedef std::pair<std::string,unsigned int> PositionType;
 
    ////
     //
@@ -158,11 +158,11 @@ class METAIO_EXPORT MetaDTITube : public MetaObject
 
     int m_NPoints;      // "NPoints = "         0
 
-    METAIO_STL::string m_PointDim; // "PointDim = "       "x y z r"
+    std::string m_PointDim; // "PointDim = "       "x y z r"
 
     PointListType m_PointList;
     MET_ValueEnumType m_ElementType;
-    METAIO_STL::vector<PositionType> m_Positions;
+    std::vector<PositionType> m_Positions;
 
     int GetPosition(const char*) const;
   };

--- a/src/metaEllipse.cxx
+++ b/src/metaEllipse.cxx
@@ -35,7 +35,7 @@ MetaEllipse::
 MetaEllipse()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaEllipse()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaEllipse()" << std::endl;
   Clear();
 
 }
@@ -45,7 +45,7 @@ MetaEllipse::
 MetaEllipse(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaEllipse()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaEllipse()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -55,7 +55,7 @@ MetaEllipse::
 MetaEllipse(const MetaEllipse *_ellipse)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaEllipse()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaEllipse()" << std::endl;
   Clear();
   CopyInfo(_ellipse);
 }
@@ -64,7 +64,7 @@ MetaEllipse::
 MetaEllipse(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaEllipse()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaEllipse()" << std::endl;
   Clear();
 }
 
@@ -80,12 +80,12 @@ void MetaEllipse::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "Radius = ";
+  std::cout << "Radius = ";
   for(int i=0;i<m_NDims;i++)
   {
-    METAIO_STREAM::cout << m_Radius[i] << " ";
+    std::cout << m_Radius[i] << " ";
   }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 }
 
 void MetaEllipse::
@@ -138,7 +138,7 @@ Radius() const
 void MetaEllipse::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaEllipse: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaEllipse: Clear" << std::endl;
   MetaObject::Clear();
   memset(m_Radius, 0, 100*sizeof(float));
 
@@ -159,7 +159,7 @@ M_Destroy()
 void MetaEllipse::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaEllipse: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaEllipse: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -191,15 +191,15 @@ M_SetupWriteFields()
 bool MetaEllipse::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaEllipse: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaEllipse: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaEllipse: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaEllipse: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaEllipse: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaEllipse: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 

--- a/src/metaFEMObject.cxx
+++ b/src/metaFEMObject.cxx
@@ -68,7 +68,7 @@ FEMObjectLoad::FEMObjectLoad()
 
 FEMObjectLoad::~FEMObjectLoad()
 {
-  for(METAIO_STL::vector<FEMObjectMFCTerm *>::iterator it = this->m_LHS.begin();
+  for(std::vector<FEMObjectMFCTerm *>::iterator it = this->m_LHS.begin();
       it != this->m_LHS.end();
       ++it)
     {
@@ -87,7 +87,7 @@ MetaFEMObject::
 MetaFEMObject()
  :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaFEMObject()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaFEMObject()" << std::endl;
 
   Clear();
 
@@ -124,7 +124,7 @@ MetaFEMObject(const char *_headerName)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject()" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject()" << std::endl;
     }
   Clear();
   Read(_headerName);
@@ -138,7 +138,7 @@ MetaFEMObject(const MetaFEMObject *_mesh)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject()" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject()" << std::endl;
     }
   Clear();
   CopyInfo(_mesh);
@@ -153,7 +153,7 @@ MetaFEMObject(unsigned int dim)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject()" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject()" << std::endl;
     }
   Clear();
   this->m_ElementDataFileName = "LOCAL";
@@ -220,12 +220,12 @@ Clear()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: Clear" << std::endl;
     }
   MetaObject::Clear();
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject: Clear: m_NPoints" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: Clear: m_NPoints" << std::endl;
     }
 
   // Delete the list of pointers to Nodes.
@@ -283,7 +283,7 @@ M_SetupReadFields()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject: M_SetupReadFields" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: M_SetupReadFields" << std::endl;
     }
 
   MetaObject::M_SetupReadFields();
@@ -321,24 +321,24 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject: M_Read: Loading Header" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: M_Read: Loading Header" << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaFEMObject: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaFEMObject: M_Read: Parsing Header" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: M_Read: Parsing Header" << std::endl;
     }
 
   // currently reader handles only ASCII data
   if(m_BinaryData)
     {
-    METAIO_STREAM::cout << "MetaFEMObject: M_Read: Data content should be in ASCII format" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: M_Read: Data content should be in ASCII format" << std::endl;
     return false;
     }
 
@@ -379,7 +379,7 @@ M_Read()
       errorMessage += "'.\nRest of line is '";
       errorMessage += rest;
       errorMessage += "'.\n";
-      METAIO_STREAM::cout << errorMessage << METAIO_STREAM::endl;
+      std::cout << errorMessage << std::endl;
       return false;  // the file is not in proper format
       }
     this->m_ReadStream->getline(buf, 256, '>');  // read up to 256 characters until '>' is reached.
@@ -417,7 +417,7 @@ M_Read()
         errorMessage = s;
         errorMessage += "   is not a valid FEM data type";
         errorMessage += "'.";
-        METAIO_STREAM::cout << errorMessage << METAIO_STREAM::endl;
+        std::cout << errorMessage << std::endl;
         return false;  // class not found
         }
       /*
@@ -450,7 +450,7 @@ M_Write()
 {
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaFEMObject: M_Write: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaFEMObject: M_Write: Error parsing file" << std::endl;
     return false;
     }
 
@@ -613,7 +613,7 @@ void MetaFEMObject::M_Write_Load(FEMObjectLoad *Load)
     for ( size_t i = 0; i < numRows; i++ )
       {
       *this->m_WriteStream << "\t";
-      METAIO_STL::vector<float> F = Load->m_ForceMatrix[i];
+      std::vector<float> F = Load->m_ForceMatrix[i];
       for ( size_t j = 0; j < numCols; j++ )
         {
         *this->m_WriteStream << F[j] << " ";
@@ -714,7 +714,7 @@ bool MetaFEMObject::M_Read_Node()
 
   if(GN == -1)
     {
-    METAIO_STREAM::cout << "Error reading Global Number" << METAIO_STREAM::endl;
+    std::cout << "Error reading Global Number" << std::endl;
     return false;
     }
   /*
@@ -724,7 +724,7 @@ bool MetaFEMObject::M_Read_Node()
   this->SkipWhiteSpace(); *this->m_ReadStream >> n;
   if ( !this->m_ReadStream)
     {
-    METAIO_STREAM::cout << "Error reading Node dimensions" << METAIO_STREAM::endl;
+    std::cout << "Error reading Node dimensions" << std::endl;
     return false;
     }
   FEMObjectNode *node = new FEMObjectNode(n);
@@ -736,7 +736,7 @@ bool MetaFEMObject::M_Read_Node()
     *this->m_ReadStream >> coor[i];
     if ( !this->m_ReadStream )
       {
-      METAIO_STREAM::cout << "Error reading Node coordinates" << METAIO_STREAM::endl;
+      std::cout << "Error reading Node coordinates" << std::endl;
       return false;
       }
     node->m_X[i] = coor[i];
@@ -755,7 +755,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
 
   if(GN == -1)
     {
-    METAIO_STREAM::cout << "Error reading Global Number" << METAIO_STREAM::endl;
+    std::cout << "Error reading Global Number" << std::endl;
     return false;
     }
   /*
@@ -790,7 +790,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
                                                  // reached. we read and discard the ':'
     if ( !this->m_ReadStream )
       {
-      METAIO_STREAM::cout << "Error reading Material properties" << METAIO_STREAM::endl;
+      std::cout << "Error reading Material properties" << std::endl;
       return false;
       }    // no : was found
     s = std::string(buf);
@@ -824,7 +824,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
       *this->m_ReadStream >> d;
       if ( !this->m_ReadStream )
         {
-        METAIO_STREAM::cout << "Error reading Material E property" << METAIO_STREAM::endl;
+        std::cout << "Error reading Material E property" << std::endl;
         return false;
         }
       E = d;
@@ -836,7 +836,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
       *this->m_ReadStream >> d;
       if ( !this->m_ReadStream )
         {
-        METAIO_STREAM::cout << "Error reading Material A property" << METAIO_STREAM::endl;
+        std::cout << "Error reading Material A property" << std::endl;
         return false;
         }
       A = d;
@@ -849,7 +849,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
       *this->m_ReadStream >> d;
       if ( !this->m_ReadStream )
         {
-        METAIO_STREAM::cout << "Error reading Material I property" << METAIO_STREAM::endl;
+        std::cout << "Error reading Material I property" << std::endl;
         return false;
         }
       I = d;
@@ -862,7 +862,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
       *this->m_ReadStream >> d;
       if ( !this->m_ReadStream )
         {
-        METAIO_STREAM::cout << "Error reading Material nu property" << METAIO_STREAM::endl;
+        std::cout << "Error reading Material nu property" << std::endl;
         return false;
         }
       nu = d;
@@ -875,7 +875,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
       *this->m_ReadStream >> d;
       if ( !this->m_ReadStream )
         {
-        METAIO_STREAM::cout << "Error reading Material h property" << METAIO_STREAM::endl;
+        std::cout << "Error reading Material h property" << std::endl;
         return false;
         }
       h = d;
@@ -888,7 +888,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
       *this->m_ReadStream >> d;
       if ( !this->m_ReadStream )
         {
-        METAIO_STREAM::cout << "Error reading Material RhoC property" << METAIO_STREAM::endl;
+        std::cout << "Error reading Material RhoC property" << std::endl;
         return false;
         }
       RhoC = d;
@@ -921,7 +921,7 @@ bool MetaFEMObject::M_Read_Material(std::string material_name)
 
   if ( !this->m_ReadStream )
     {
-    METAIO_STREAM::cout << "Error reading Material properties" << METAIO_STREAM::endl;
+    std::cout << "Error reading Material properties" << std::endl;
     return false;
     }
   return true;
@@ -937,7 +937,7 @@ bool MetaFEMObject::M_Read_Element(std::string element_name)
 
   if(GN == -1)
     {
-    METAIO_STREAM::cout << "Error reading Global Number" << METAIO_STREAM::endl;
+    std::cout << "Error reading Global Number" << std::endl;
     return false;
     }
   /*
@@ -950,7 +950,7 @@ bool MetaFEMObject::M_Read_Element(std::string element_name)
     if ( !this->m_ReadStream )
       {
       delete [] NodesId;
-      METAIO_STREAM::cout << "Error reading Element node numbers" << METAIO_STREAM::endl;
+      std::cout << "Error reading Element node numbers" << std::endl;
       return false;
       }
     NodesId[p] = n;
@@ -961,7 +961,7 @@ bool MetaFEMObject::M_Read_Element(std::string element_name)
   if ( !this->m_ReadStream )
     {
     delete [] NodesId;
-    METAIO_STREAM::cout << "Error reading Element global number" << METAIO_STREAM::endl;
+    std::cout << "Error reading Element global number" << std::endl;
     return false;
     }
   // store the read information
@@ -999,7 +999,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
   if (GN == -1)
     {
     delete load;
-    METAIO_STREAM::cout << "Error reading Load definition - global number" << METAIO_STREAM::endl;
+    std::cout << "Error reading Load definition - global number" << std::endl;
     return false;
     }
 
@@ -1013,7 +1013,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading Load definition - Element Global Number" << METAIO_STREAM::endl;
+      std::cout << "Error reading Load definition - Element Global Number" << std::endl;
       return false;
       }
     load->m_ElementGN = elementGN;
@@ -1024,7 +1024,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading Load definition - Degrees of Freedom" << METAIO_STREAM::endl;
+      std::cout << "Error reading Load definition - Degrees of Freedom" << std::endl;
       return false;
       }
     load->m_DOF = DOF;
@@ -1035,7 +1035,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading Load definition - Number of fixed degrees of freedom" << METAIO_STREAM::endl;
+      std::cout << "Error reading Load definition - Number of fixed degrees of freedom" << std::endl;
       return false;
       }
     load->m_NumRHS = NumRHS;
@@ -1048,7 +1048,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading Load definition - Fixed degree of freedom" << METAIO_STREAM::endl;
+        std::cout << "Error reading Load definition - Fixed degree of freedom" << std::endl;
         return false;
         }
       }
@@ -1061,7 +1061,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadNode definition - Element Global Number" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadNode definition - Element Global Number" << std::endl;
       return false;
       }
     load->m_ElementGN = elementGN;
@@ -1072,7 +1072,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadNode definition - Node Number" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadNode definition - Node Number" << std::endl;
       return false;
       }
     load->m_NodeNumber = NodeNumber;
@@ -1082,7 +1082,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadNode definition - Dimension" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadNode definition - Dimension" << std::endl;
       return false;
       }
     load->m_Dim = Dim;
@@ -1095,7 +1095,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadNode definition - Force Vector" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadNode definition - Force Vector" << std::endl;
         return false;
         }
       }
@@ -1108,7 +1108,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if(!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadBCMFC definition - Number of LHS terms" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadBCMFC definition - Number of LHS terms" << std::endl;
       return false;
       }
 
@@ -1121,7 +1121,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadBCMFC definition - Element Global Number" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadBCMFC definition - Element Global Number" << std::endl;
         return false;
         }
 
@@ -1131,7 +1131,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadBCMFC definition - Element Degree of Freedom" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadBCMFC definition - Element Degree of Freedom" << std::endl;
         return false;
         }
 
@@ -1141,7 +1141,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadBCMFC definition - Weight" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadBCMFC definition - Weight" << std::endl;
         return false;
         }
 
@@ -1156,7 +1156,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadBCMFC definition - Number of RHS terms" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadBCMFC definition - Number of RHS terms" << std::endl;
       return false;
       }
 
@@ -1169,7 +1169,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadBCMFC definition - RHS Term" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadBCMFC definition - RHS Term" << std::endl;
         return false;
         }
       }
@@ -1184,7 +1184,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadEdge definition - Element Global Number" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadEdge definition - Element Global Number" << std::endl;
       return false;
       }
     load->m_ElementGN = elementGN;
@@ -1195,7 +1195,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadEdge definition - Edge Number" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadEdge definition - Edge Number" << std::endl;
       return false;
       }
     load->m_EdgeNumber = edgeNum;
@@ -1206,7 +1206,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadEdge definition - Number of Rows" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadEdge definition - Number of Rows" << std::endl;
       return false;
       }
 
@@ -1216,21 +1216,21 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadEdge definition - Number of Columns" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadEdge definition - Number of Columns" << std::endl;
       return false;
       }
 
     for ( int i = 0; i < numRows; i++ )
       {
       this->SkipWhiteSpace();
-      METAIO_STL::vector<float> F(numCols);
+      std::vector<float> F(numCols);
       for ( int j = 0; j < numCols; j++ )
         {
         *this->m_ReadStream >> F[j];
         if (!this->m_ReadStream)
           {
           delete load;
-          METAIO_STREAM::cout << "Error reading LoadEdge definition - Force Matrix" << METAIO_STREAM::endl;
+          std::cout << "Error reading LoadEdge definition - Force Matrix" << std::endl;
           return false;
           }
         }
@@ -1246,7 +1246,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadGravConst definition - Number of Elements" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadGravConst definition - Number of Elements" << std::endl;
       return false;
       }
 
@@ -1257,7 +1257,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if (!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadGravConst definition - Element Global Number" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadGravConst definition - Element Global Number" << std::endl;
         return false;
         }
       load->m_Elements.push_back(elementGN);
@@ -1269,7 +1269,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if (!this->m_ReadStream)
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading LoadGravConst definition - Dimension" << METAIO_STREAM::endl;
+      std::cout << "Error reading LoadGravConst definition - Dimension" << std::endl;
       return false;
       }
 
@@ -1282,7 +1282,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if (!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading LoadGravConst definition - Force Vector" << METAIO_STREAM::endl;
+        std::cout << "Error reading LoadGravConst definition - Force Vector" << std::endl;
         return false;
         }
       load->m_ForceVector.push_back(loadcomp);
@@ -1306,7 +1306,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading Loadlandmark definition - Undeformed point" << METAIO_STREAM::endl;
+        std::cout << "Error reading Loadlandmark definition - Undeformed point" << std::endl;
         return false;
         }
       }
@@ -1324,7 +1324,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
       if(!this->m_ReadStream)
         {
         delete load;
-        METAIO_STREAM::cout << "Error reading Loadlandmark definition - Undeformed point" << METAIO_STREAM::endl;
+        std::cout << "Error reading Loadlandmark definition - Undeformed point" << std::endl;
         return false;
         }
       }
@@ -1333,7 +1333,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
     if ( n1 != n2 )
       {
       delete load;
-      METAIO_STREAM::cout << "Error reading Loadlandmark definition - Undeformed point and deformed point should have same dimension" << METAIO_STREAM::endl;
+      std::cout << "Error reading Loadlandmark definition - Undeformed point and deformed point should have same dimension" << std::endl;
       return false;
       }
     // read the square root of the m_Variance associated with this landmark
@@ -1343,7 +1343,7 @@ bool MetaFEMObject::M_Read_Load(std::string load_name)
   if(!this->m_ReadStream)
     {
     delete load;
-    METAIO_STREAM::cout << "Error reading Load definition" << METAIO_STREAM::endl;
+    std::cout << "Error reading Load definition" << std::endl;
     return false;
     }
   this->m_LoadList.push_back(load);

--- a/src/metaFEMObject.h
+++ b/src/metaFEMObject.h
@@ -179,19 +179,19 @@ public:
   char m_LoadName[256]; // load name
   int m_ElementGN;
   int m_Dim;
-  METAIO_STL::vector<float> m_ForceVector;
+  std::vector<float> m_ForceVector;
   int m_DOF;
   int m_NodeNumber;
   int m_NumRHS;
-  METAIO_STL::vector<float> m_RHS;
+  std::vector<float> m_RHS;
   int m_NumLHS;
-  METAIO_STL::vector<FEMObjectMFCTerm*> m_LHS;
+  std::vector<FEMObjectMFCTerm*> m_LHS;
   int m_NumElements;
-  METAIO_STL::vector<int> m_Elements;
-  METAIO_STL::vector< METAIO_STL::vector<float> > m_ForceMatrix;
+  std::vector<int> m_Elements;
+  std::vector< std::vector<float> > m_ForceMatrix;
   int m_EdgeNumber;
-  METAIO_STL::vector<float> m_Undeformed;
-  METAIO_STL::vector<float> m_Deformed;
+  std::vector<float> m_Undeformed;
+  std::vector<float> m_Deformed;
   float m_Variance;
 };
 
@@ -221,13 +221,13 @@ public:
   void  Clear(void) override;
 
   /** List of valid class name types from FEM namespace*/
-  typedef METAIO_STL::list<std::string> ClassNameListType;
+  typedef std::list<std::string> ClassNameListType;
 
   /** List of Node, Element, Material and Load*/
-  typedef METAIO_STL::list<FEMObjectNode*> NodeListType;
-  typedef METAIO_STL::list<FEMObjectElement*>  ElementListType;
-  typedef METAIO_STL::list<FEMObjectMaterial*>  MaterialListType;
-  typedef METAIO_STL::list<FEMObjectLoad*>  LoadListType;
+  typedef std::list<FEMObjectNode*> NodeListType;
+  typedef std::list<FEMObjectElement*>  ElementListType;
+  typedef std::list<FEMObjectMaterial*>  MaterialListType;
+  typedef std::list<FEMObjectLoad*>  LoadListType;
 
   /** Access methods*/
   NodeListType & GetNodeList(void) {return m_NodeList;}

--- a/src/metaForm.cxx
+++ b/src/metaForm.cxx
@@ -95,51 +95,51 @@ PrintInfo() const
   {
   int i;
 
-  METAIO_STREAM::cout << "ReadStream = "
+  std::cout << "ReadStream = "
                       << ((m_ReadStream==nullptr)?"NULL":"Set")
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "WriteStream = "
+                      << std::endl;
+  std::cout << "WriteStream = "
                       << ((m_WriteStream==nullptr)?"NULL":"Set")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "FileName = _" << m_FileName << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Comment = _" << m_Comment << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "FormTypeName = _" << m_FormTypeName << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Name = " << m_Name << METAIO_STREAM::endl;
+  std::cout << "FileName = _" << m_FileName << "_"
+                      << std::endl;
+  std::cout << "Comment = _" << m_Comment << "_"
+                      << std::endl;
+  std::cout << "FormTypeName = _" << m_FormTypeName << "_"
+                      << std::endl;
+  std::cout << "Name = " << m_Name << std::endl;
   if(m_BinaryData)
     {
-    METAIO_STREAM::cout << "BinaryData = True" << METAIO_STREAM::endl;
+    std::cout << "BinaryData = True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "BinaryData = False" << METAIO_STREAM::endl;
+    std::cout << "BinaryData = False" << std::endl;
     }
   if(m_BinaryDataByteOrderMSB)
     {
-    METAIO_STREAM::cout << "BinaryDataByteOrderMSB = True"
-                        << METAIO_STREAM::endl;
+    std::cout << "BinaryDataByteOrderMSB = True"
+                        << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "BinaryDataByteOrderMSB = False"
-                        << METAIO_STREAM::endl;
+    std::cout << "BinaryDataByteOrderMSB = False"
+                        << std::endl;
     }
   if(m_CompressedData)
     {
-    METAIO_STREAM::cout << "CompressedData = True" << METAIO_STREAM::endl;
+    std::cout << "CompressedData = True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "CompressedData = False" << METAIO_STREAM::endl;
+    std::cout << "CompressedData = False" << std::endl;
     }
-  METAIO_STREAM::cout << "DoublePrecision = " << m_DoublePrecision
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Event = "
+  std::cout << "DoublePrecision = " << m_DoublePrecision
+                      << std::endl;
+  std::cout << "Event = "
                       << ((m_Event==nullptr)?"NULL":"Set")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
   // Print User's fields :
   FieldsContainerType::const_iterator  itw = m_UserDefinedWriteFields.begin();
@@ -193,17 +193,17 @@ PrintInfo() const
       }
     else if((*it)->type == MET_FLOAT_MATRIX)
       {
-      METAIO_STREAM::cout << METAIO_STREAM::endl;
+      std::cout << std::endl;
       for(i=0; i<(*it)->length*(*it)->length; i++)
         {
         printf("%f ",(*it)->value[i]);
         if(i==(*it)->length-1)
           {
-          METAIO_STREAM::cout << METAIO_STREAM::endl;
+          std::cout << std::endl;
           }
         }
       }
-    METAIO_STREAM::cout << METAIO_STREAM::endl;
+    std::cout << std::endl;
 
     ++itw;
     ++itr;
@@ -236,7 +236,7 @@ Clear()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: Clear()" << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Clear()" << std::endl;
     }
 
   // Preserve m_FileName
@@ -260,7 +260,7 @@ ClearFields()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm:ClearFields" << METAIO_STREAM::endl;
+    std::cout << "MetaForm:ClearFields" << std::endl;
     }
 
   FieldsContainerType::iterator  it  = m_Fields.begin();
@@ -315,7 +315,7 @@ InitializeEssential()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: Initialize" << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Initialize" << std::endl;
     }
 
   M_Destroy();
@@ -599,7 +599,7 @@ Read(const char *_fileName)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: Read" << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Read" << std::endl;
     }
 
   if(_fileName != nullptr)
@@ -607,21 +607,21 @@ Read(const char *_fileName)
     strcpy(m_FileName, _fileName);
     }
 
-  METAIO_STREAM::cout << "Read FileName = _" << m_FileName << "_"
-                      << METAIO_STREAM::endl;
+  std::cout << "Read FileName = _" << m_FileName << "_"
+                      << std::endl;
 
-  METAIO_STREAM::ifstream * tmpReadStream = new METAIO_STREAM::ifstream;
+  std::ifstream * tmpReadStream = new std::ifstream;
 #ifdef __sgi
-  tmpReadStream->open(m_FileName, METAIO_STREAM::ios::in);
+  tmpReadStream->open(m_FileName, std::ios::in);
 #else
-  tmpReadStream->open(m_FileName, METAIO_STREAM::ios::binary |
-                                  METAIO_STREAM::ios::in);
+  tmpReadStream->open(m_FileName, std::ios::binary |
+                                  std::ios::in);
 #endif
 
   if(!tmpReadStream->rdbuf()->is_open())
     {
-    METAIO_STREAM::cout << "MetaForm: Read: Cannot open file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Read: Cannot open file"
+                        << std::endl;
     delete tmpReadStream;
     return false;
     }
@@ -642,7 +642,7 @@ Read(const char *_fileName)
   }
 
 bool MetaForm::
-CanReadStream(METAIO_STREAM::ifstream * _stream) const
+CanReadStream(std::ifstream * _stream) const
   {
   if(_stream)
     {
@@ -655,11 +655,11 @@ CanReadStream(METAIO_STREAM::ifstream * _stream) const
   }
 
 bool MetaForm::
-ReadStream(METAIO_STREAM::ifstream * _stream)
+ReadStream(std::ifstream * _stream)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: ReadStream" << METAIO_STREAM::endl;
+    std::cout << "MetaForm: ReadStream" << std::endl;
     }
 
   M_Destroy();
@@ -690,27 +690,27 @@ Write(const char *_fileName)
     FileName(_fileName);
     }
 
-  METAIO_STREAM::cout << "Write FileName = _" << m_FileName << "_"
-                      << METAIO_STREAM::endl;
+  std::cout << "Write FileName = _" << m_FileName << "_"
+                      << std::endl;
 
-  METAIO_STREAM::ofstream * tmpWriteStream = new METAIO_STREAM::ofstream;
+  std::ofstream * tmpWriteStream = new std::ofstream;
 
 #ifdef __sgi
   {
   // Create the file. This is required on some older sgi's
-  METAIO_STREAM::ofstream tFile(m_FileName, METAIO_STREAM::ios::out);
+  std::ofstream tFile(m_FileName, std::ios::out);
   tFile.close();
   }
-  tmpWriteStream->open(m_FileName, METAIO_STREAM::ios::out);
+  tmpWriteStream->open(m_FileName, std::ios::out);
 #else
-  tmpWriteStream->open(m_FileName, METAIO_STREAM::ios::binary |
-                                  METAIO_STREAM::ios::out);
+  tmpWriteStream->open(m_FileName, std::ios::binary |
+                                  std::ios::out);
 #endif
 
   if(!tmpWriteStream->rdbuf()->is_open())
     {
     delete tmpWriteStream;
-    METAIO_STREAM::cout << "Write failed." << METAIO_STREAM::endl;
+    std::cout << "Write failed." << std::endl;
     return false;
     }
 
@@ -724,7 +724,7 @@ Write(const char *_fileName)
   }
 
 bool MetaForm::
-WriteStream(METAIO_STREAM::ofstream * _stream)
+WriteStream(std::ofstream * _stream)
   {
   M_SetupWriteFields();
 
@@ -745,7 +745,7 @@ M_Destroy()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: Destroy" << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Destroy" << std::endl;
     }
   }
 
@@ -755,8 +755,8 @@ M_SetupReadFields()
   this->ClearFields();
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: M_SetupReadFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaForm: M_SetupReadFields"
+                        << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -801,16 +801,16 @@ M_SetupWriteFields()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: M_SetupWriteFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaForm: M_SetupWriteFields"
+                        << std::endl;
     }
 
   this->ClearFields();
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaForm: M_SetupWriteFields: Creating Fields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaForm: M_SetupWriteFields: Creating Fields"
+                        << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -889,8 +889,8 @@ M_Read()
 
   if(!MET_Read(*m_ReadStream, & m_Fields))
     {
-    METAIO_STREAM::cout << "MetaForm: Read: MET_Read Failed"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Read: MET_Read Failed"
+                        << std::endl;
     return false;
     }
 
@@ -989,8 +989,8 @@ M_Write()
 
   if(!MET_Write(*m_WriteStream, & m_Fields))
     {
-    METAIO_STREAM::cout << "MetaForm: Write: MET_Write Failed"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaForm: Write: MET_Write Failed"
+                        << std::endl;
     return false;
     }
 

--- a/src/metaForm.h
+++ b/src/metaForm.h
@@ -138,13 +138,13 @@ class METAIO_EXPORT MetaForm
 
     bool  Read(const char * _fileName=NULL);
 
-    bool  CanReadStream(METAIO_STREAM::ifstream * _stream) const;
+    bool  CanReadStream(std::ifstream * _stream) const;
 
-    bool  ReadStream(METAIO_STREAM::ifstream * _stream);
+    bool  ReadStream(std::ifstream * _stream);
 
     bool  Write(const char * _fileName=NULL);
 
-    bool  WriteStream(METAIO_STREAM::ofstream * _stream);
+    bool  WriteStream(std::ofstream * _stream);
 
   ////
   //
@@ -153,10 +153,10 @@ class METAIO_EXPORT MetaForm
   ////
   protected:
 
-    typedef METAIO_STL::vector<MET_FieldRecordType *> FieldsContainerType;
+    typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
-    METAIO_STREAM::ifstream *  m_ReadStream;
-    METAIO_STREAM::ofstream *  m_WriteStream;
+    std::ifstream *  m_ReadStream;
+    std::ofstream *  m_WriteStream;
 
     char  m_FileName[255];
 

--- a/src/metaGaussian.cxx
+++ b/src/metaGaussian.cxx
@@ -30,7 +30,7 @@ MetaGaussian::
 MetaGaussian()
 :MetaObject( )
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGaussian()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGaussian()" << std::endl;
   Clear();
 
 }
@@ -40,7 +40,7 @@ MetaGaussian::
 MetaGaussian(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaGaussian()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaGaussian()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -50,7 +50,7 @@ MetaGaussian::
 MetaGaussian(const MetaGaussian *_gaussian)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaGaussian()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaGaussian()" << std::endl;
   Clear();
   CopyInfo(_gaussian);
 }
@@ -59,7 +59,7 @@ MetaGaussian::
 MetaGaussian(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGaussian()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGaussian()" << std::endl;
   Clear();
 }
 
@@ -75,11 +75,11 @@ void MetaGaussian::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "\n"
+  std::cout << "\n"
             << "Maximum = " << m_Maximum << "\n"
             << "Radius = " << m_Radius
             << "Sigma = " << m_Sigma
-            << METAIO_STREAM::endl;
+            << std::endl;
 }
 
 void MetaGaussian::
@@ -92,7 +92,7 @@ CopyInfo(const MetaObject * _object)
 void MetaGaussian::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGaussian: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGaussian: Clear" << std::endl;
   MetaObject::Clear();
   m_Maximum = 1;
   m_Radius = 1;
@@ -110,7 +110,7 @@ M_Destroy()
 void MetaGaussian::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGaussian: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGaussian: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -158,17 +158,17 @@ M_SetupWriteFields()
 bool MetaGaussian::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGaussian: M_Read: Loading Header"
-                           << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGaussian: M_Read: Loading Header"
+                           << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaGaussian: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaGaussian: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGaussian: M_Read: Parsing Header"
-                           << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGaussian: M_Read: Parsing Header"
+                           << std::endl;
 
   MET_FieldRecordType * mF;
 

--- a/src/metaGroup.cxx
+++ b/src/metaGroup.cxx
@@ -30,7 +30,7 @@ MetaGroup::
 MetaGroup()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGroup()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGroup()" << std::endl;
   Clear();
 
 }
@@ -40,7 +40,7 @@ MetaGroup::
 MetaGroup(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaGroup()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaGroup()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -50,7 +50,7 @@ MetaGroup::
 MetaGroup(const MetaGroup *_group)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaGroup()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaGroup()" << std::endl;
   Clear();
   CopyInfo(_group);
 }
@@ -59,7 +59,7 @@ MetaGroup::
 MetaGroup(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGroup()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGroup()" << std::endl;
   Clear();
 }
 
@@ -87,7 +87,7 @@ CopyInfo(const MetaObject * _object)
 void MetaGroup::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGroup: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGroup: Clear" << std::endl;
   MetaObject::Clear();
 }
 
@@ -102,7 +102,7 @@ M_Destroy()
 void MetaGroup::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaGroup: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaGroup: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -132,18 +132,18 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaGroup: M_Read: Loading Header" << METAIO_STREAM::endl;
+    std::cout << "MetaGroup: M_Read: Loading Header" << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaGroup: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaGroup: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaGroup: M_Read: Parsing Header" << METAIO_STREAM::endl;
+    std::cout << "MetaGroup: M_Read: Parsing Header" << std::endl;
     }
 
   return true;

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -41,23 +41,23 @@
 
 namespace {
 
-void openReadStream(METAIO_STREAM::ifstream & inputStream, const char * fname)
+void openReadStream(std::ifstream & inputStream, const char * fname)
 {
 #ifdef __sgi
-  inputStream.open( fname, METAIO_STREAM::ios::in );
+  inputStream.open( fname, std::ios::in );
 #else
-  inputStream.open( fname, METAIO_STREAM::ios::in |
-                           METAIO_STREAM::ios::binary );
+  inputStream.open( fname, std::ios::in |
+                           std::ios::binary );
 #endif
 }
 
-void openWriteStream(METAIO_STREAM::ofstream & outputStream, const char * fname, bool append)
+void openWriteStream(std::ofstream & outputStream, const char * fname, bool append)
 {
 // Some older sgi compilers have a error in the ofstream constructor
 // that requires a file to exist for output
 #ifdef __sgi
   {
-  METAIO_STREAM::ofstream tFile(fname, METAIO_STREAM::ios::out);
+  std::ofstream tFile(fname, std::ios::out);
   tFile.close();
   }
 #endif
@@ -65,21 +65,21 @@ void openWriteStream(METAIO_STREAM::ofstream & outputStream, const char * fname,
   if(!append)
     {
 #ifdef __sgi
-    outputStream.open(fname, METAIO_STREAM::ios::out);
+    outputStream.open(fname, std::ios::out);
 #else
-    outputStream.open(fname, METAIO_STREAM::ios::binary |
-                             METAIO_STREAM::ios::out);
+    outputStream.open(fname, std::ios::binary |
+                             std::ios::out);
 #endif
     }
   else
     {
 #ifdef __sgi
-    outputStream.open(fname, METAIO_STREAM::ios::app |
-                             METAIO_STREAM::ios::out);
+    outputStream.open(fname, std::ios::app |
+                             std::ios::out);
 #else
-    outputStream.open(fname, METAIO_STREAM::ios::binary |
-                             METAIO_STREAM::ios::app |
-                             METAIO_STREAM::ios::out);
+    outputStream.open(fname, std::ios::binary |
+                             std::ios::app |
+                             std::ios::out);
 #endif
     }
 }
@@ -93,7 +93,7 @@ namespace METAIO_NAMESPACE {
 #endif
 
 // 1 Gigabyte is the maximum chunk to read/write in on function call
-static const METAIO_STL::streamoff MaxIOChunk = 1024*1024*1024;
+static const std::streamoff MaxIOChunk = 1024*1024*1024;
 
 //
 // MetaImage Constructors
@@ -104,7 +104,7 @@ MetaImage()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    std::cout << "MetaImage()" << std::endl;
     }
 
   m_CompressionTable = new MET_CompressionTableType;
@@ -120,7 +120,7 @@ MetaImage(const char *_headerName)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    std::cout << "MetaImage()" << std::endl;
     }
 
   m_CompressionTable = new MET_CompressionTableType;
@@ -138,7 +138,7 @@ MetaImage(MetaImage *_im)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    std::cout << "MetaImage()" << std::endl;
     }
 
   m_CompressionTable = new MET_CompressionTableType;
@@ -167,7 +167,7 @@ InitHelper(int _nDims,
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    std::cout << "MetaImage()" << std::endl;
     }
 
   m_CompressionTable = new MET_CompressionTableType;
@@ -242,7 +242,7 @@ MetaImage(int _x, int _y,
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    std::cout << "MetaImage()" << std::endl;
     }
 
   m_CompressionTable = new MET_CompressionTableType;
@@ -293,7 +293,7 @@ MetaImage(int _x, int _y, int _z,
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage()" << METAIO_STREAM::endl;
+    std::cout << "MetaImage()" << std::endl;
     }
 
   m_CompressionTable = new MET_CompressionTableType;
@@ -350,78 +350,78 @@ PrintInfo() const
 
   char s[MAXPATHLENGTH];
   MET_ImageModalityToString(m_Modality, s);
-  METAIO_STREAM::cout << "Modality = " << s << METAIO_STREAM::endl;
+  std::cout << "Modality = " << s << std::endl;
 
-  METAIO_STREAM::cout << "DimSize = ";
+  std::cout << "DimSize = ";
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_DimSize[i] << " ";
+    std::cout << m_DimSize[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "SubQuantity = ";
+  std::cout << std::endl;
+  std::cout << "SubQuantity = ";
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_SubQuantity[i] << " ";
+    std::cout << m_SubQuantity[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
-  METAIO_STREAM::cout << "Quantity = " << m_Quantity << METAIO_STREAM::endl;
+  std::cout << "Quantity = " << m_Quantity << std::endl;
 
 
-  METAIO_STREAM::cout << "HeaderSize = " << m_HeaderSize << METAIO_STREAM::endl;
+  std::cout << "HeaderSize = " << m_HeaderSize << std::endl;
 
-  METAIO_STREAM::cout << "SequenceID = ";
+  std::cout << "SequenceID = ";
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_SequenceID[i] << " ";
+    std::cout << m_SequenceID[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
-  METAIO_STREAM::cout << "ElementSizeValid = " << (int)m_ElementSizeValid
-            << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "ElementSize = ";
+  std::cout << "ElementSizeValid = " << (int)m_ElementSizeValid
+            << std::endl;
+  std::cout << "ElementSize = ";
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_ElementSize[i] << " ";
+    std::cout << m_ElementSize[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
   char str[MAXPATHLENGTH];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 
-  METAIO_STREAM::cout << "ElementNumberOfChannels = "
-                      << m_ElementNumberOfChannels << METAIO_STREAM::endl;
+  std::cout << "ElementNumberOfChannels = "
+                      << m_ElementNumberOfChannels << std::endl;
 
   if(m_ElementMinMaxValid)
     {
-    METAIO_STREAM::cout << "Min and Max are valid" << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "   Min = " << m_ElementMin << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "   Max = " << m_ElementMax << METAIO_STREAM::endl;
+    std::cout << "Min and Max are valid" << std::endl;
+    std::cout << "   Min = " << m_ElementMin << std::endl;
+    std::cout << "   Max = " << m_ElementMax << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "Min and Max are not valid" << METAIO_STREAM::endl;
+    std::cout << "Min and Max are not valid" << std::endl;
     }
 
-  METAIO_STREAM::cout << "ElementToIntensityFunctionSlope = "
+  std::cout << "ElementToIntensityFunctionSlope = "
                       << m_ElementToIntensityFunctionSlope
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "ElementToIntensityFunctionOffset = "
+                      << std::endl;
+  std::cout << "ElementToIntensityFunctionOffset = "
                       << m_ElementToIntensityFunctionOffset
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
 
-  METAIO_STREAM::cout << "AutoFreeElementData = "
+  std::cout << "AutoFreeElementData = "
                       << ((m_AutoFreeElementData)?"True":"False")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "ElementData = "
+  std::cout << "ElementData = "
                       << ((m_ElementData==nullptr)?"NULL":"Valid")
-                      << METAIO_STREAM::endl;
+                      << std::endl;
 
-  METAIO_STREAM::cout << "ElementDataFileName = "
-                      << m_ElementDataFileName << METAIO_STREAM::endl;
+  std::cout << "ElementDataFileName = "
+                      << m_ElementDataFileName << std::endl;
 
   }
 
@@ -474,7 +474,7 @@ void MetaImage::Clear()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaImage: Clear" << std::endl;
     }
 
   m_Modality = MET_MOD_UNKNOWN;
@@ -564,7 +564,7 @@ InitializeEssential(int _nDims,
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: Initialize" << METAIO_STREAM::endl;
+    std::cout << "MetaImage: Initialize" << std::endl;
     }
 
   MetaObject::InitializeEssential(_nDims);
@@ -614,8 +614,8 @@ InitializeEssential(int _nDims,
     m_ElementData = new char[static_cast<size_t>(m_Quantity*m_ElementNumberOfChannels*i)];
     if(m_ElementData == nullptr)
       {
-      METAIO_STREAM::cerr << "MetaImage:: M_Allocate:: Insufficient memory"
-                          << METAIO_STREAM::endl;
+      std::cerr << "MetaImage:: M_Allocate:: Insufficient memory"
+                          << std::endl;
       return false;
       }
     }
@@ -677,7 +677,7 @@ DimSize(int _i) const
 //
 //
 //
-METAIO_STL::streamoff MetaImage::
+std::streamoff MetaImage::
 Quantity() const
   {
   return m_Quantity;
@@ -686,13 +686,13 @@ Quantity() const
 //
 //
 //
-const METAIO_STL::streamoff * MetaImage::
+const std::streamoff * MetaImage::
 SubQuantity() const
   {
   return m_SubQuantity;
   }
 
-METAIO_STL::streamoff MetaImage::
+std::streamoff MetaImage::
 SubQuantity(int _i) const
   {
   return m_SubQuantity[_i];
@@ -811,16 +811,16 @@ ElementNumberOfChannels(int _elementNumberOfChannels)
 //
 //
 void MetaImage::
-ElementByteOrderSwap(METAIO_STL::streamoff _quantity)
+ElementByteOrderSwap(std::streamoff _quantity)
   {
 
   // use the user provided value if provided or the internal ivar
-  METAIO_STL::streamoff quantity = _quantity ? _quantity : m_Quantity;
+  std::streamoff quantity = _quantity ? _quantity : m_Quantity;
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: ElementByteOrderSwap"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaImage: ElementByteOrderSwap"
+                        << std::endl;
     }
 
   int eSize;
@@ -869,7 +869,7 @@ ElementByteOrderSwap(METAIO_STL::streamoff _quantity)
   }
 
 bool MetaImage::
-ElementByteOrderFix(METAIO_STL::streamoff _quantity)
+ElementByteOrderFix(std::streamoff _quantity)
   {
   if(m_BinaryDataByteOrderMSB != MET_SystemByteOrderMSB())
     {
@@ -1015,7 +1015,7 @@ ElementData()
   }
 
 double MetaImage::
-ElementData(METAIO_STL::streamoff _i) const
+ElementData(std::streamoff _i) const
   {
   double tf = 0;
   MET_ValueToDouble(m_ElementType, m_ElementData, _i, &tf);
@@ -1024,7 +1024,7 @@ ElementData(METAIO_STL::streamoff _i) const
   }
 
 bool MetaImage::
-ElementData(METAIO_STL::streamoff _i, double _v)
+ElementData(std::streamoff _i, double _v)
   {
   if(_i<m_Quantity)
     {
@@ -1178,35 +1178,35 @@ bool MetaImage::FileIsFullPath(const char* in_name) const
 }
 
 // Return the value of a tag
-METAIO_STL::string
+std::string
 MetaImage::
-M_GetTagValue(const METAIO_STL::string & buffer, const char* tag) const
+M_GetTagValue(const std::string & buffer, const char* tag) const
 {
   size_t stringPos = buffer.find(tag);
-  if( stringPos == METAIO_STL::string::npos )
+  if( stringPos == std::string::npos )
     {
     return "";
     }
 
   size_t pos2 = buffer.find('=',stringPos);
-  if(pos2 == METAIO_STL::string::npos )
+  if(pos2 == std::string::npos )
     {
     pos2 = buffer.find(':',stringPos);
     }
 
-  if(pos2 == METAIO_STL::string::npos )
+  if(pos2 == std::string::npos )
     {
     return "";
     }
 
   size_t posend = buffer.find('\r',pos2);
-  if(posend == METAIO_STL::string::npos )
+  if(posend == std::string::npos )
     {
     posend = buffer.find('\n',pos2);
     }
 
   // Get the element data filename
-  METAIO_STL::string value = "";
+  std::string value = "";
   bool firstspace = true;
   size_t index = pos2+1;
   while(index<buffer.size()
@@ -1235,7 +1235,7 @@ bool MetaImage::
 CanRead(const char *_headerName) const
   {
   // First check the extension
-  METAIO_STL::string fname = _headerName;
+  std::string fname = _headerName;
   if(  fname == "" )
     {
     return false;
@@ -1243,15 +1243,15 @@ CanRead(const char *_headerName) const
 
   bool extensionFound = false;
 
-  METAIO_STL::string::size_type stringPos = fname.rfind(".mhd");
-  if ((stringPos != METAIO_STL::string::npos)
+  std::string::size_type stringPos = fname.rfind(".mhd");
+  if ((stringPos != std::string::npos)
       && (stringPos == fname.length() - 4))
     {
     extensionFound = true;
     }
 
   stringPos = fname.rfind(".mha");
-  if ((stringPos != METAIO_STL::string::npos)
+  if ((stringPos != std::string::npos)
       && (stringPos == fname.length() - 4))
     {
     extensionFound = true;
@@ -1263,7 +1263,7 @@ CanRead(const char *_headerName) const
     }
 
   // Now check the file content
-  METAIO_STREAM::ifstream inputStream;
+  std::ifstream inputStream;
 
   openReadStream(inputStream, fname.c_str());
 
@@ -1276,18 +1276,18 @@ CanRead(const char *_headerName) const
   inputStream.read(buf,8000);
   unsigned long fileSize = static_cast<unsigned long>(inputStream.gcount());
   buf[fileSize] = 0;
-  METAIO_STL::string header(buf);
+  std::string header(buf);
   header.resize(fileSize);
   delete [] buf;
   inputStream.close();
 
   stringPos = header.find("NDims");
-  if( stringPos == METAIO_STL::string::npos )
+  if( stringPos == std::string::npos )
     {
     return false;
     }
 
-  METAIO_STL::string elementDataFileName = M_GetTagValue(header,"ElementDataFile");
+  std::string elementDataFileName = M_GetTagValue(header,"ElementDataFile");
 
   return true;
   }
@@ -1308,7 +1308,7 @@ Read(const char *_headerName, bool _readElements, void * _buffer)
 
   M_PrepareNewReadStream();
 
-  METAIO_STREAM::ifstream * tmpReadStream = new METAIO_STREAM::ifstream;
+  std::ifstream * tmpReadStream = new std::ifstream;
 
   openReadStream(*tmpReadStream, m_FileName);
 
@@ -1333,7 +1333,7 @@ Read(const char *_headerName, bool _readElements, void * _buffer)
   }
 
 bool MetaImage::
-CanReadStream(METAIO_STREAM::ifstream * _stream) const
+CanReadStream(std::ifstream * _stream) const
   {
   if(!strncmp(MET_ReadType(*_stream).c_str(), "Image", 5))
     {
@@ -1345,14 +1345,14 @@ CanReadStream(METAIO_STREAM::ifstream * _stream) const
 
 bool MetaImage::
 ReadStream(int _nDims,
-           METAIO_STREAM::ifstream * _stream,
+           std::ifstream * _stream,
            bool _readElements,
            void * _buffer)
   {
   if(!MetaObject::ReadStream(_nDims, _stream))
     {
-    METAIO_STREAM::cerr << "MetaImage: Read: Cannot parse file"
-                        << METAIO_STREAM::endl;
+    std::cerr << "MetaImage: Read: Cannot parse file"
+                        << std::endl;
     return false;
     }
 
@@ -1412,7 +1412,7 @@ ReadStream(int _nDims,
         fileImageDim = m_NDims-1;
         }
       char s[1024];
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
       int elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
       elementSize *= m_ElementNumberOfChannels;
@@ -1443,8 +1443,8 @@ ReadStream(int _nDims,
           openReadStream(*readStreamTemp, fName);
           if(!readStreamTemp->is_open())
             {
-            METAIO_STREAM::cerr << "MetaImage: Read: cannot open slice"
-                                << METAIO_STREAM::endl;
+            std::cerr << "MetaImage: Read: cannot open slice"
+                                << std::endl;
             continue;
             }
           M_ReadElements(readStreamTemp,
@@ -1468,7 +1468,7 @@ ReadStream(int _nDims,
       int maxV = m_DimSize[m_NDims-1];
       int stepV = 1;
       char s[MAXPATHLENGTH];
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
       MET_StringToWordArray(m_ElementDataFileName, &nWrds, &wrds);
       if(nWrds >= 2)
         {
@@ -1497,8 +1497,8 @@ ReadStream(int _nDims,
           {
             if( !isdigit(wrds[i][j]) )
             {
-              METAIO_STREAM::cerr << "MetaImage: Read: Last three arguments must be numbers!"
-                  << METAIO_STREAM::endl;
+              std::cerr << "MetaImage: Read: Last three arguments must be numbers!"
+                  << std::endl;
               continue;
             }
           }
@@ -1537,8 +1537,8 @@ ReadStream(int _nDims,
         openReadStream(*readStreamTemp,fName);
         if(!readStreamTemp->is_open())
           {
-          METAIO_STREAM::cerr << "MetaImage: Read: cannot construct file"
-                              << METAIO_STREAM::endl;
+          std::cerr << "MetaImage: Read: cannot construct file"
+                              << std::endl;
           continue;
           }
 
@@ -1568,12 +1568,12 @@ ReadStream(int _nDims,
         strcpy(fName, m_ElementDataFileName);
         }
 
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
 
       const char *extensions[] = { "", ".gz", ".Z", nullptr };
       for(unsigned ii = 0; extensions[ii] != nullptr; ii++)
         {
-        METAIO_STL::string tempFName(fName);
+        std::string tempFName(fName);
         tempFName += extensions[ii];
         openReadStream(*readStreamTemp,tempFName.c_str());
         if(readStreamTemp->is_open())
@@ -1589,8 +1589,8 @@ ReadStream(int _nDims,
 
       if(!readStreamTemp->is_open())
         {
-        METAIO_STREAM::cerr << "MetaImage: Read: Cannot open data file"
-                            << METAIO_STREAM::endl;
+        std::cerr << "MetaImage: Read: Cannot open data file"
+                            << std::endl;
         if(m_ReadStream)
           {
           m_ReadStream->close();
@@ -1682,7 +1682,7 @@ Write(const char *_headName,
       }
     }
 
-  METAIO_STREAM::ofstream * tmpWriteStream = new METAIO_STREAM::ofstream;
+  std::ofstream * tmpWriteStream = new std::ofstream;
 
   openWriteStream(*tmpWriteStream, m_FileName, _append);
 
@@ -1714,14 +1714,14 @@ Write(const char *_headName,
   }
 
 bool MetaImage::
-WriteStream(METAIO_STREAM::ofstream * _stream,
+WriteStream(std::ofstream * _stream,
             bool _writeElements,
             const void * _constElementData)
   {
   if(m_WriteStream != nullptr)
     {
-    METAIO_STREAM::cerr << "MetaArray: WriteStream: two files open?"
-                        << METAIO_STREAM::endl;
+    std::cerr << "MetaArray: WriteStream: two files open?"
+                        << std::endl;
     delete m_WriteStream;
     }
 
@@ -1820,20 +1820,20 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
       }
     if( elementData == nullptr )
       {
-      METAIO_STREAM::cerr << "Element data is NULL" << METAIO_STREAM::endl;
+      std::cerr << "Element data is NULL" << std::endl;
       return false;
       }
 
     // Find the start of the data
-    METAIO_STREAM::ifstream * readStream = new METAIO_STREAM::ifstream;
-    readStream->open( m_FileName, METAIO_STREAM::ios::binary |
-                                  METAIO_STREAM::ios::in);
+    std::ifstream * readStream = new std::ifstream;
+    readStream->open( m_FileName, std::ios::binary |
+                                  std::ios::in);
 
     // File must be readable
     if( !MetaObject::ReadStream( m_NDims, readStream ) )
       {
-      METAIO_STREAM::cerr << "MetaImage: Read: Cannot parse file"
-                          << METAIO_STREAM::endl;
+      std::cerr << "MetaImage: Read: Cannot parse file"
+                          << std::endl;
       delete readStream;
       return false;
       }
@@ -1841,9 +1841,9 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     // File must not be compressed
     if(m_CompressedData)
       {
-      METAIO_STREAM::cerr
+      std::cerr
                << "MetaImage cannot insert ROI into a compressed file."
-               << METAIO_STREAM::endl;
+               << std::endl;
       readStream->close();
       delete readStream;
       return false;
@@ -1856,8 +1856,8 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
                          m_ElementNumberOfChannels,
                          nullptr, false ); // no memory allocation
 
-    METAIO_STL::string  filename = ElementDataFileName();
-    METAIO_STL::streampos dataPos = 0;
+    std::string  filename = ElementDataFileName();
+    std::streampos dataPos = 0;
 
     // local file
     if( filename == "LOCAL" )
@@ -1868,9 +1868,9 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     else if( filename == "LIST"
              || strstr(filename.c_str(), "%") )
       {
-      METAIO_STREAM::cerr
+      std::cerr
                << "MetaImage cannot insert ROI into a list of files."
-               << METAIO_STREAM::endl;
+               << std::endl;
       readStream->close();
       delete readStream;
       return false;
@@ -1887,17 +1887,17 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
       filename = pathName+filename;
       }
 
-    METAIO_STREAM::ofstream * tmpWriteStream = new METAIO_STREAM::ofstream;
+    std::ofstream * tmpWriteStream = new std::ofstream;
     tmpWriteStream->open( filename.c_str(),
-                          METAIO_STREAM::ios::binary |
-                          METAIO_STREAM::ios::in |
-                          METAIO_STREAM::ios::out );
+                          std::ios::binary |
+                          std::ios::in |
+                          std::ios::out );
 
     if( !tmpWriteStream->is_open() )
       {
-      METAIO_STREAM::cerr << "Cannot open ROI file: "
+      std::cerr << "Cannot open ROI file: "
                           << filename.c_str()
-                          << METAIO_STREAM::endl;
+                          << std::endl;
       delete tmpWriteStream;
       return false;
       }
@@ -1907,19 +1907,19 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     int elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
 
     // seek to the end and write one byte to allocate the entire file size
-    METAIO_STL::streamoff seekoff = m_Quantity*elementNumberOfBytes;
-    tmpWriteStream->seekp(0, METAIO_STREAM::ios::end);
+    std::streamoff seekoff = m_Quantity*elementNumberOfBytes;
+    tmpWriteStream->seekp(0, std::ios::end);
     if (tmpWriteStream->tellp() != (dataPos+seekoff))
       {
       seekoff = seekoff - 1;
-      tmpWriteStream->seekp(dataPos+seekoff, METAIO_STREAM::ios::beg);
+      tmpWriteStream->seekp(dataPos+seekoff, std::ios::beg);
       const char zerobyte = 0;
       tmpWriteStream->write(&zerobyte, 1);
       }
 
     if( !elementData )
       {
-      METAIO_STREAM::cerr << "Element data is NULL" << METAIO_STREAM::endl;
+      std::cerr << "Element data is NULL" << std::endl;
       delete tmpWriteStream;
       return false;
       }
@@ -1934,9 +1934,9 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     {
     if(m_CompressedData)
       {
-      METAIO_STREAM::cerr
+      std::cerr
                << "MetaImage cannot write an ROI using compression."
-               << METAIO_STREAM::endl;
+               << std::endl;
       return false;
       }
 
@@ -1977,9 +1977,9 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     if( !strcmp(m_ElementDataFileName, "LIST")
         || strstr(m_ElementDataFileName, "%") )
       {
-      METAIO_STREAM::cerr
+      std::cerr
                << "MetaImage cannot insert ROI into a list of files."
-               << METAIO_STREAM::endl;
+               << std::endl;
       return false;
       }
 
@@ -2010,7 +2010,7 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
         }
       }
 
-    METAIO_STREAM::ofstream * tmpWriteStream = new METAIO_STREAM::ofstream;
+    std::ofstream * tmpWriteStream = new std::ofstream;
 
     openWriteStream(*tmpWriteStream, m_FileName, _append);
 
@@ -2036,7 +2036,7 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     M_SetupWriteFields();
     M_Write();
 
-    METAIO_STL::streampos dataPos = m_WriteStream->tellp();
+    std::streampos dataPos = m_WriteStream->tellp();
 
     // If data is in a separate file, set dataPos and point to that file.
     //   ( we've already verified the name isn't LIST and doesn't
@@ -2067,9 +2067,9 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
     int elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
 
     // write the last byte in the file to allocate it
-    METAIO_STL::streamoff seekoff = m_Quantity * elementNumberOfBytes;
+    std::streamoff seekoff = m_Quantity * elementNumberOfBytes;
     seekoff -= 1;
-    m_WriteStream->seekp(seekoff, METAIO_STREAM::ios::cur);
+    m_WriteStream->seekp(seekoff, std::ios::cur);
     const char zerobyte = 0;
     m_WriteStream->write(&zerobyte, 1);
 
@@ -2091,9 +2091,9 @@ bool MetaImage::WriteROI( int * _indexMin, int * _indexMax,
 }
 
 bool  MetaImage::
-M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
+M_WriteElementsROI(std::ofstream * _fstream,
                    const void * _data,
-                   METAIO_STL::streampos _dataPos,
+                   std::streampos _dataPos,
                    int * _indexMin,
                    int* _indexMax )
 {
@@ -2114,7 +2114,7 @@ M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
   // region shape
   // This calculate the number of continuous bytes in the file
   // which can be written
-  METAIO_STL::streamoff elementsToWrite = 1;
+  std::streamoff elementsToWrite = 1;
   int movingDirection = 0;
   do
     {
@@ -2130,12 +2130,12 @@ M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
   while(!done)
     {
     // Seek to the right position
-    METAIO_STL::streamoff seekoff = _dataPos;
+    std::streamoff seekoff = _dataPos;
     for(int i=0; i<m_NDims; i++)
       {
       seekoff += m_SubQuantity[i] * currentIndex[i] * elementNumberOfBytes;
       }
-    _fstream->seekp( seekoff, METAIO_STREAM::ios::beg );
+    _fstream->seekp( seekoff, std::ios::beg );
 
     M_WriteElementData( _fstream, data, elementsToWrite );
     data += elementsToWrite * elementNumberOfBytes;
@@ -2177,7 +2177,7 @@ Append(const char *_headName)
   {
   if(META_DEBUG)
    {
-   METAIO_STREAM::cout << "MetaImage: Append" << METAIO_STREAM::endl;
+   std::cout << "MetaImage: Append" << std::endl;
    }
 
   return this->Write(_headName, nullptr, true, nullptr, true);
@@ -2211,8 +2211,8 @@ M_SetupReadFields()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_SetupReadFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_SetupReadFields"
+                        << std::endl;
     }
 
   MetaObject::M_SetupReadFields();
@@ -2399,27 +2399,27 @@ M_Read()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_Read: Loading Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_Read: Loading Header"
+                        << std::endl;
     }
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cerr << "MetaImage: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cerr << "MetaImage: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_Read: Parsing Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_Read: Parsing Header"
+                        << std::endl;
     }
   MET_FieldRecordType * mF;
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "metaImage: M_Read: elementSpacing[" << 0 << "] = "
-                        << m_ElementSpacing[0] << METAIO_STREAM::endl;
+    std::cout << "metaImage: M_Read: elementSpacing[" << 0 << "] = "
+                        << m_ElementSpacing[0] << std::endl;
     }
   mF = MET_GetFieldRecord("DimSize", &m_Fields);
   if(mF && mF->defined)
@@ -2542,42 +2542,42 @@ M_Read()
 //
 //
 bool MetaImage::
-M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
-               METAIO_STL::streamoff _dataQuantity)
+M_ReadElements(std::ifstream * _fstream, void * _data,
+               std::streamoff _dataQuantity)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_ReadElements" << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_ReadElements" << std::endl;
     }
 
   if(m_HeaderSize>(int)0)
     {
-    _fstream->seekg(m_HeaderSize, METAIO_STREAM::ios::beg);
+    _fstream->seekg(m_HeaderSize, std::ios::beg);
     if(!_fstream->good())
       {
-      METAIO_STREAM::cerr << "MetaImage: Read: header not read correctly"
-                          << METAIO_STREAM::endl;
+      std::cerr << "MetaImage: Read: header not read correctly"
+                          << std::endl;
       return false;
       }
     }
 
   int elementSize;
   MET_SizeOfType(m_ElementType, &elementSize);
-  METAIO_STL::streamoff readSize = _dataQuantity*m_ElementNumberOfChannels*elementSize;
+  std::streamoff readSize = _dataQuantity*m_ElementNumberOfChannels*elementSize;
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_ReadElements: ReadSize = "
-                        << readSize << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_ReadElements: ReadSize = "
+                        << readSize << std::endl;
     }
 
   if(m_HeaderSize == -1)
     {
     if(META_DEBUG)
       {
-      METAIO_STREAM::cout << "MetaImage: M_ReadElements: Skipping header"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaImage: M_ReadElements: Skipping header"
+                          << std::endl;
       }
-    _fstream->seekg(-readSize, METAIO_STREAM::ios::end);
+    _fstream->seekg(-readSize, std::ios::end);
     }
 
   // If compressed we inflate
@@ -2589,9 +2589,9 @@ M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
     if(m_CompressedDataSize==0)
       {
       compressedDataDeterminedFromFile = true;
-      _fstream->seekg(0, METAIO_STREAM::ios::end);
+      _fstream->seekg(0, std::ios::end);
       m_CompressedDataSize = _fstream->tellg();
-      _fstream->seekg(0, METAIO_STREAM::ios::beg);
+      _fstream->seekg(0, std::ios::beg);
       }
 
     unsigned char* compr = new unsigned char[static_cast<size_t>(m_CompressedDataSize)];
@@ -2629,9 +2629,9 @@ M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data,
   }
 
 bool MetaImage::
-M_WriteElements(METAIO_STREAM::ofstream * _fstream,
+M_WriteElements(std::ofstream * _fstream,
                 const void * _data,
-                METAIO_STL::streamoff _dataQuantity)
+                std::streamoff _dataQuantity)
   {
 
   if(!strcmp(m_ElementDataFileName, "LOCAL"))
@@ -2658,10 +2658,10 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream,
       char fName[MAXPATHLENGTH];
       int elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
-      METAIO_STL::streamoff elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
-      METAIO_STL::streamoff sliceNumberOfBytes = m_SubQuantity[m_NDims-1]*elementNumberOfBytes;
+      std::streamoff elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
+      std::streamoff sliceNumberOfBytes = m_SubQuantity[m_NDims-1]*elementNumberOfBytes;
 
-      METAIO_STREAM::ofstream* writeStreamTemp = new METAIO_STREAM::ofstream;
+      std::ofstream* writeStreamTemp = new std::ofstream;
       for(i=1; i<=m_DimSize[m_NDims-1]; i++)
         {
         snprintf(fName, sizeof(fName), dataFileName, i);
@@ -2679,7 +2679,7 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream,
         else
           {
           unsigned char * compressedData = nullptr;
-          METAIO_STL::streamoff compressedDataSize = 0;
+          std::streamoff compressedDataSize = 0;
 
           // Compress the data slice by slice
           compressedData = MET_PerformCompression(
@@ -2702,7 +2702,7 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream,
       }
     else // write the image in one unique other file
       {
-      METAIO_STREAM::ofstream* writeStreamTemp = new METAIO_STREAM::ofstream;
+      std::ofstream* writeStreamTemp = new std::ofstream;
       openWriteStream(*writeStreamTemp, dataFileName, false);
 
       MetaImage::M_WriteElementData(writeStreamTemp, _data, _dataQuantity);
@@ -2717,20 +2717,20 @@ M_WriteElements(METAIO_STREAM::ofstream * _fstream,
 
 
 bool MetaImage::
-M_WriteElementData(METAIO_STREAM::ofstream * _fstream,
+M_WriteElementData(std::ofstream * _fstream,
                    const void * _data,
-                   METAIO_STL::streamoff _dataQuantity)
+                   std::streamoff _dataQuantity)
   {
   if(!m_BinaryData)
     {
 
     double tf;
-    for(METAIO_STL::streamoff i=0; i<_dataQuantity; i++)
+    for(std::streamoff i=0; i<_dataQuantity; i++)
       {
       MET_ValueToDouble(m_ElementType, _data, i, &tf);
       if((i+1)/10 == (double)(i+1.0)/10.0)
         {
-        (*_fstream) << tf << METAIO_STREAM::endl;
+        (*_fstream) << tf << std::endl;
         }
       else
         {
@@ -2743,10 +2743,10 @@ M_WriteElementData(METAIO_STREAM::ofstream * _fstream,
     if(m_CompressedData)
       {
       // the data is written in writes no bigger then MaxIOChunk
-      METAIO_STL::streamoff bytesRemaining = _dataQuantity;
+      std::streamoff bytesRemaining = _dataQuantity;
       while ( bytesRemaining )
         {
-        METAIO_STL::streamoff chunkToWrite = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
+        std::streamoff chunkToWrite = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
         _fstream->write( (const char *)_data, (size_t)chunkToWrite );
         _data = (const char *)(_data) + chunkToWrite; // <- Note: data is changed
         bytesRemaining -= chunkToWrite;
@@ -2756,13 +2756,13 @@ M_WriteElementData(METAIO_STREAM::ofstream * _fstream,
       {
       int elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
-      METAIO_STL::streamoff elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
+      std::streamoff elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
 
       // the data is written in writes no bigger then MaxIOChunk
-      METAIO_STL::streamoff bytesRemaining = _dataQuantity * elementNumberOfBytes;
+      std::streamoff bytesRemaining = _dataQuantity * elementNumberOfBytes;
       while ( bytesRemaining )
         {
-        METAIO_STL::streamoff chunkToWrite = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
+        std::streamoff chunkToWrite = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
         _fstream->write( (const char *)_data, (size_t)chunkToWrite );
         _data = (const char *)(_data) + chunkToWrite; // <- Note: _data is changed
         bytesRemaining -= chunkToWrite;
@@ -2773,9 +2773,9 @@ M_WriteElementData(METAIO_STREAM::ofstream * _fstream,
   // check if the io stream did not fail in the process of writing
   if ( _fstream->fail() )
     {
-    METAIO_STREAM::cerr
+    std::cerr
       << "MetaImage: M_WriteElementsData: file stream is fail after write"
-      << METAIO_STREAM::endl;
+      << std::endl;
     return false;
     }
 
@@ -2803,7 +2803,7 @@ ReadROI(int * _indexMin, int * _indexMax,
 
   M_PrepareNewReadStream();
 
-  METAIO_STREAM::ifstream * tmpReadStream = new METAIO_STREAM::ifstream;
+  std::ifstream * tmpReadStream = new std::ifstream;
 
   openReadStream(*tmpReadStream, m_FileName);
 
@@ -2831,15 +2831,15 @@ ReadROI(int * _indexMin, int * _indexMax,
 /** Read the ROI Stream */
 bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
                               int _nDims,
-                              METAIO_STREAM::ifstream * _stream,
+                              std::ifstream * _stream,
                               bool _readElements,
                               void * _buffer,
                               unsigned int subSamplingFactor)
 {
   if(!MetaObject::ReadStream(_nDims, _stream))
     {
-    METAIO_STREAM::cerr << "MetaImage: Read: Cannot parse file"
-                        << METAIO_STREAM::endl;
+    std::cerr << "MetaImage: Read: Cannot parse file"
+                        << std::endl;
     return false;
     }
 
@@ -2865,7 +2865,7 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
       }
 
     // Streaming related. We need to update some of the fields
-    METAIO_STL::streamoff quantity = 1;
+    std::streamoff quantity = 1;
     int i;
     size_t j;
     for(i=0; i<m_NDims; i++)
@@ -2908,7 +2908,7 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
         fileImageDim = m_NDims-1;
         }
       char s[1024];
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
       int elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
       elementSize *= m_ElementNumberOfChannels;
@@ -2946,8 +2946,8 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
           openReadStream(*readStreamTemp, fName);
           if(!readStreamTemp->is_open())
             {
-            METAIO_STREAM::cerr << "MetaImage: Read: cannot open slice"
-                                << METAIO_STREAM::endl;
+            std::cerr << "MetaImage: Read: cannot open slice"
+                                << std::endl;
             continue;
             }
 
@@ -2989,7 +2989,7 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
       int maxV = m_DimSize[m_NDims-1];
       int stepV = 1;
       char s[MAXPATHLENGTH];
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
       MET_StringToWordArray(m_ElementDataFileName, &nWrds, &wrds);
       if(nWrds >= 2)
         {
@@ -3018,8 +3018,8 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
           {
             if( !isdigit(wrds[i][j]) )
             {
-              METAIO_STREAM::cerr << "MetaImage: Read: Last three arguments must be numbers!"
-                  << METAIO_STREAM::endl;
+              std::cerr << "MetaImage: Read: Last three arguments must be numbers!"
+                  << std::endl;
               continue;
             }
           }
@@ -3066,8 +3066,8 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
         openReadStream(*readStreamTemp, fName);
         if(!readStreamTemp->is_open())
           {
-          METAIO_STREAM::cerr << "MetaImage: Read: cannot construct file"
-                              << METAIO_STREAM::endl;
+          std::cerr << "MetaImage: Read: cannot construct file"
+                              << std::endl;
           continue;
           }
 
@@ -3118,12 +3118,12 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
         strcpy(fName, m_ElementDataFileName);
         }
 
-      METAIO_STREAM::ifstream* readStreamTemp = new METAIO_STREAM::ifstream;
+      std::ifstream* readStreamTemp = new std::ifstream;
 
       const char *extensions[] = { "", ".gz", ".Z", nullptr };
       for(unsigned ii = 0; extensions[ii] != nullptr; ii++)
         {
-        METAIO_STL::string tempFName(fName);
+        std::string tempFName(fName);
         tempFName += extensions[ii];
         openReadStream(*readStreamTemp,tempFName.c_str());
         if(readStreamTemp->is_open())
@@ -3139,8 +3139,8 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
 
       if(!readStreamTemp->is_open())
         {
-        METAIO_STREAM::cerr << "MetaImage: ReadROI: Cannot open data file"
-                            << METAIO_STREAM::endl;
+        std::cerr << "MetaImage: ReadROI: Cannot open data file"
+                            << std::endl;
         if(m_ReadStream)
           {
           m_ReadStream->close();
@@ -3162,10 +3162,10 @@ bool MetaImage::ReadROIStream(int * _indexMin, int * _indexMax,
 
 /** Read an ROI */
 bool MetaImage::
-M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
-                  METAIO_STL::streamoff _dataQuantity,
+M_ReadElementsROI(std::ifstream * _fstream, void * _data,
+                  std::streamoff _dataQuantity,
                   int* _indexMin, int* _indexMax,unsigned int subSamplingFactor,
-                  METAIO_STL::streamoff _totalDataQuantity)
+                  std::streamoff _totalDataQuantity)
 {
   if(_totalDataQuantity ==0)
     {
@@ -3181,44 +3181,44 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_ReadElementsROI" << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_ReadElementsROI" << std::endl;
     }
 
   if(m_HeaderSize>(int)0)
     {
-    _fstream->seekg(m_HeaderSize, METAIO_STREAM::ios::beg);
+    _fstream->seekg(m_HeaderSize, std::ios::beg);
     if(!_fstream->good())
       {
-      METAIO_STREAM::cerr << "MetaImage: M_ReadElementsROI: header not read correctly"
-                          << METAIO_STREAM::endl;
+      std::cerr << "MetaImage: M_ReadElementsROI: header not read correctly"
+                          << std::endl;
       return false;
       }
     }
 
   int elementSize;
   MET_SizeOfType(m_ElementType, &elementSize);
-  METAIO_STL::streamoff readSize = _dataQuantity*m_ElementNumberOfChannels*elementSize;
+  std::streamoff readSize = _dataQuantity*m_ElementNumberOfChannels*elementSize;
   int elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaImage: M_ReadElementsROI: ReadSize = "
-                        << readSize << METAIO_STREAM::endl;
+    std::cout << "MetaImage: M_ReadElementsROI: ReadSize = "
+                        << readSize << std::endl;
     }
 
   if(m_HeaderSize == -1)
     {
     if(META_DEBUG)
       {
-      METAIO_STREAM::cout << "MetaImage: M_ReadElementsROI: Skipping header"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaImage: M_ReadElementsROI: Skipping header"
+                          << std::endl;
       }
-    METAIO_STL::streamoff headSize = _totalDataQuantity*m_ElementNumberOfChannels*elementSize;
-    _fstream->seekg(-headSize, METAIO_STREAM::ios::end);
+    std::streamoff headSize = _totalDataQuantity*m_ElementNumberOfChannels*elementSize;
+    _fstream->seekg(-headSize, std::ios::end);
     }
 
-  METAIO_STL::streampos dataPos = _fstream->tellg();
-  METAIO_STL::streamoff i;
+  std::streampos dataPos = _fstream->tellg();
+  std::streamoff i;
 
   // If compressed we inflate
   if(m_BinaryData && m_CompressedData)
@@ -3227,9 +3227,9 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
     // file is the size of the compressed data
     if(m_CompressedDataSize==0)
       {
-      _fstream->seekg(0, METAIO_STREAM::ios::end);
+      _fstream->seekg(0, std::ios::end);
       m_CompressedDataSize = _fstream->tellg();
-      _fstream->seekg(0, METAIO_STREAM::ios::beg);
+      _fstream->seekg(0, std::ios::beg);
       }
 
       unsigned char* data = static_cast<unsigned char*>(_data);
@@ -3244,7 +3244,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
       // region shape
       // This calculate the number of continuous bytes in the file
       // which can be read
-      METAIO_STL::streamoff elementsToRead = 1;
+      std::streamoff elementsToRead = 1;
       int movingDirection = 0;
       do
         {
@@ -3256,14 +3256,14 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
             && _indexMin[movingDirection-1] == 0
             && _indexMax[movingDirection-1] == m_DimSize[movingDirection-1]-1);
 
-      METAIO_STL::streamoff bytesToRead = elementsToRead*elementNumberOfBytes;
-      METAIO_STL::streamoff gc = 0;
+      std::streamoff bytesToRead = elementsToRead*elementNumberOfBytes;
+      std::streamoff gc = 0;
 
       bool done = false;
       while(!done)
         {
         // Seek to the right position
-        METAIO_STL::streamoff seekoff = 0;
+        std::streamoff seekoff = 0;
         for(i=0; i<m_NDims; i++)
           {
           seekoff += m_SubQuantity[i]*elementNumberOfBytes*currentIndex[i];
@@ -3273,7 +3273,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
         if(subSamplingFactor > 1)
           {
           unsigned char* subdata = new unsigned char[static_cast<size_t>(bytesToRead)];
-          METAIO_STL::streamoff rOff =
+          std::streamoff rOff =
             MET_UncompressStream(_fstream, seekoff, subdata,
                                  bytesToRead, m_CompressedDataSize,
                                  m_CompressionTable);
@@ -3284,7 +3284,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
             return false;
             }
 
-          for(METAIO_STL::streamoff p=0;
+          for(std::streamoff p=0;
               p<bytesToRead;
               p+=(subSamplingFactor*m_ElementNumberOfChannels*elementSize))
             {
@@ -3299,7 +3299,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
           }
         else
           {
-          METAIO_STL::streamoff rOff =
+          std::streamoff rOff =
             MET_UncompressStream(_fstream, seekoff, data,
                                  bytesToRead, m_CompressedDataSize,
                                  m_CompressionTable);
@@ -3346,11 +3346,11 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
 
       if(gc != readSize)
         {
-        METAIO_STREAM::cerr
+        std::cerr
                   << "MetaImage: M_ReadElementsROI: data not read completely"
-                  << METAIO_STREAM::endl;
-        METAIO_STREAM::cerr << "   ideal = " << readSize << " : actual = " << gc
-                  << METAIO_STREAM::endl;
+                  << std::endl;
+        std::cerr << "   ideal = " << readSize << " : actual = " << gc
+                  << std::endl;
         delete [] currentIndex;
         return false;
         }
@@ -3374,7 +3374,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
     // region shape
     // This calculate the number of continuous bytes in the file
     // which can be read
-    METAIO_STL::streamoff elementsToRead = 1;
+    std::streamoff elementsToRead = 1;
     int movingDirection = 0;
     do
       {
@@ -3387,19 +3387,19 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
           && _indexMax[movingDirection-1] == m_DimSize[movingDirection-1]-1);
 
     //readLine *= m_ElementNumberOfChannels*elementSize;
-    METAIO_STL::streamoff gc = 0;
+    std::streamoff gc = 0;
 
     bool done = false;
     while(!done)
       {
       // Seek to the right position
-      METAIO_STL::streamoff seekoff = 0;
+      std::streamoff seekoff = 0;
       for(i=0;i<m_NDims;i++)
         {
         seekoff += m_SubQuantity[i]*m_ElementNumberOfChannels*elementSize*currentIndex[i];
         }
 
-      _fstream->seekg(dataPos+seekoff, METAIO_STREAM::ios::beg);
+      _fstream->seekg(dataPos+seekoff, std::ios::beg);
 
       // Read a line
       if(subSamplingFactor > 1)
@@ -3423,7 +3423,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
 
           _fstream->read(subdata, size_t(elementsToRead*elementNumberOfBytes));
 
-          for(METAIO_STL::streamoff p=0;
+          for(std::streamoff p=0;
               p<elementsToRead*elementNumberOfBytes;
               p+=(subSamplingFactor*elementNumberOfBytes))
             {
@@ -3444,7 +3444,7 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
           // anyone using ROI reading of ASCII??
           // does this work? what about incrementing data?
           // what about data sizes and random access of file?
-          METAIO_STL::streamoff blockSize = elementsToRead*m_ElementNumberOfChannels*elementSize;
+          std::streamoff blockSize = elementsToRead*m_ElementNumberOfChannels*elementSize;
           M_ReadElementData(  _fstream, data, (size_t)blockSize  );
           gc += blockSize;
 
@@ -3496,11 +3496,11 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
 
     if(gc != readSize)
       {
-      METAIO_STREAM::cerr
+      std::cerr
                 << "MetaImage: M_ReadElementsROI: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cerr << "   ideal = " << readSize << " : actual = " << gc
-                << METAIO_STREAM::endl;
+                << std::endl;
+      std::cerr << "   ideal = " << readSize << " : actual = " << gc
+                << std::endl;
       return false;
       }
     }
@@ -3510,12 +3510,12 @@ M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream, void * _data,
 
 
 bool MetaImage::
-M_ReadElementData(METAIO_STREAM::ifstream * _fstream,
+M_ReadElementData(std::ifstream * _fstream,
                   void * _data,
-                  METAIO_STL::streamoff _dataQuantity)
+                  std::streamoff _dataQuantity)
 {
   // NOTE: this method is different from WriteElementData
-  METAIO_STL::streamoff gc = 0;
+  std::streamoff gc = 0;
 
   if(!m_BinaryData)
     {
@@ -3535,14 +3535,14 @@ M_ReadElementData(METAIO_STREAM::ifstream * _fstream,
       {
 
       // the data is read with calls no bigger then MaxIOChunk
-      METAIO_STL::streamoff bytesRemaining = _dataQuantity;
+      std::streamoff bytesRemaining = _dataQuantity;
       while ( bytesRemaining )
         {
-        METAIO_STL::streamoff chunkToRead = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
+        std::streamoff chunkToRead = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
         _fstream->read( (char *)_data, (size_t)chunkToRead );
         _data = (char *)(_data) + chunkToRead;
         bytesRemaining -= chunkToRead;
-        METAIO_STL::streamsize numberOfBytesRead = _fstream->gcount();
+        std::streamsize numberOfBytesRead = _fstream->gcount();
         gc += numberOfBytesRead;
         }
 
@@ -3551,17 +3551,17 @@ M_ReadElementData(METAIO_STREAM::ifstream * _fstream,
       {
       int elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
-      METAIO_STL::streamoff elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
+      std::streamoff elementNumberOfBytes = elementSize*m_ElementNumberOfChannels;
 
       // the data is read with calls no bigger than MaxIOChunk
-      METAIO_STL::streamoff bytesRemaining = _dataQuantity * elementNumberOfBytes;
+      std::streamoff bytesRemaining = _dataQuantity * elementNumberOfBytes;
       while ( bytesRemaining )
         {
-        METAIO_STL::streamoff chunkToRead = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
+        std::streamoff chunkToRead = bytesRemaining > MaxIOChunk ? MaxIOChunk : bytesRemaining;
         _fstream->read( (char *)_data, (size_t)chunkToRead );
         _data = (char *)(_data) + chunkToRead;
         bytesRemaining -= chunkToRead;
-        METAIO_STL::streamsize numberOfBytesRead = _fstream->gcount();
+        std::streamsize numberOfBytesRead = _fstream->gcount();
         gc += numberOfBytesRead;
         }
       // convert to number of bytes so that it'll match gc's units
@@ -3572,20 +3572,20 @@ M_ReadElementData(METAIO_STREAM::ifstream * _fstream,
   // check that we actually read the correct number of bytes
   if( gc != _dataQuantity )
     {
-    METAIO_STREAM::cerr
+    std::cerr
       << "MetaImage: M_ReadElementsData: data not read completely"
-      << METAIO_STREAM::endl;
-    METAIO_STREAM::cerr << "   ideal = " << _dataQuantity << " : actual = " << gc
-                        << METAIO_STREAM::endl;
+      << std::endl;
+    std::cerr << "   ideal = " << _dataQuantity << " : actual = " << gc
+                        << std::endl;
     return false;
     }
 
   // check if the io stream did not fail in the process of reading
   if ( _fstream->fail() )
     {
-    METAIO_STREAM::cerr
+    std::cerr
       << "MetaImage: M_ReadElementsData: file stream is fail after read"
-      << METAIO_STREAM::endl;
+      << std::endl;
     return false;
     }
 

--- a/src/metaImage.h
+++ b/src/metaImage.h
@@ -149,14 +149,14 @@ class METAIO_EXPORT MetaImage : public MetaObject
     //    Quantity()
     //       Not a field in file
     //       Total number of elements in image (Prod(dimSize[i]))
-    METAIO_STL::streamoff  Quantity(void) const;
+    std::streamoff  Quantity(void) const;
 
     //    SubQuantity(...)
     //       Not a field in file
     //       Number of elements in image spanning sub-dimensions
     //       E.g., elements per line, 2D sub-image, 3D sub-volume,
-    const METAIO_STL::streamoff * SubQuantity(void) const;
-    METAIO_STL::streamoff SubQuantity(int _i) const;
+    const std::streamoff * SubQuantity(void) const;
+    std::streamoff SubQuantity(int _i) const;
 
     //    SequenceID(...)
     //       Optional Field
@@ -193,8 +193,8 @@ class METAIO_EXPORT MetaImage : public MetaObject
     // if streaming is used, then the size of buffer in total number
     // of elements, should be passed as an argument, otherwise the
     // internal value Quantity() will be used
-    void  ElementByteOrderSwap( METAIO_STL::streamoff _quantity = 0);
-    bool  ElementByteOrderFix( METAIO_STL::streamoff _quantity = 0);
+    void  ElementByteOrderSwap( std::streamoff _quantity = 0);
+    bool  ElementByteOrderFix( std::streamoff _quantity = 0);
 
     //    Min(...) Max(...)
     //       The default max returned is the largest allowed by
@@ -234,8 +234,8 @@ class METAIO_EXPORT MetaImage : public MetaObject
     //
     //
     void * ElementData(void);
-    double ElementData(METAIO_STL::streamoff _i) const;
-    bool   ElementData(METAIO_STL::streamoff _i, double _v);
+    double ElementData(std::streamoff _i) const;
+    bool   ElementData(std::streamoff _i, double _v);
     void   ElementData(void * _data, bool _autoFreeElementData=false);
 
     //    ConverTo(...)
@@ -265,16 +265,16 @@ class METAIO_EXPORT MetaImage : public MetaObject
                          );
 
 
-    bool CanReadStream(METAIO_STREAM::ifstream * _stream) const;
+    bool CanReadStream(std::ifstream * _stream) const;
 
     bool ReadStream(int _nDims,
-                            METAIO_STREAM::ifstream * _stream,
+                            std::ifstream * _stream,
                             bool _readElements=true,
                             void * _buffer=NULL);
 
     bool ReadROIStream(int * _indexMin, int * _indexMax,
                                int _nDims,
-                               METAIO_STREAM::ifstream * _stream,
+                               std::ifstream * _stream,
                                bool _readElements=true,
                                void * _buffer=NULL,
                                unsigned int subSamplingFactor=1);
@@ -293,7 +293,7 @@ class METAIO_EXPORT MetaImage : public MetaObject
                           bool _append=false
                           );
 
-    bool WriteStream(METAIO_STREAM::ofstream * _stream,
+    bool WriteStream(std::ofstream * _stream,
                              bool _writeElements=true,
                              const void * _constElementData=NULL);
 
@@ -301,7 +301,7 @@ class METAIO_EXPORT MetaImage : public MetaObject
     bool Append(const char *_headName=NULL) override;
 
 
-    typedef METAIO_STL::pair<long,long> CompressionOffsetType;
+    typedef std::pair<long,long> CompressionOffsetType;
 
   ////
   //
@@ -316,8 +316,8 @@ class METAIO_EXPORT MetaImage : public MetaObject
     MET_CompressionTableType*  m_CompressionTable;
 
     int                    m_DimSize[10];
-    METAIO_STL::streamoff m_SubQuantity[10];
-    METAIO_STL::streamoff m_Quantity;
+    std::streamoff m_SubQuantity[10];
+    std::streamoff m_Quantity;
 
     int                m_HeaderSize;
 
@@ -354,44 +354,44 @@ class METAIO_EXPORT MetaImage : public MetaObject
 
     // _dataQuantity is expressed in number of pixels. Internally it will be
     // scaled by the number of components and number of bytes per component.
-    bool  M_ReadElements(METAIO_STREAM::ifstream * _fstream,
+    bool  M_ReadElements(std::ifstream * _fstream,
                          void * _data,
-                         METAIO_STL::streamoff _dataQuantity);
+                         std::streamoff _dataQuantity);
 
     // _totalDataQuantity and _dataQuantity are expressed in number of pixels.
     // Internally they will be scaled by the number of components and number of
     // bytes per component.
-    bool  M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream,
+    bool  M_ReadElementsROI(std::ifstream * _fstream,
                             void * _data,
-                            METAIO_STL::streamoff _dataQuantity,
+                            std::streamoff _dataQuantity,
                             int * _indexMin,
                             int* _indexMax,
                             unsigned int subSamplingFactor=1,
-                            METAIO_STL::streamoff _totalDataQuantity=0);
+                            std::streamoff _totalDataQuantity=0);
 
-    bool M_ReadElementData(METAIO_STREAM::ifstream * _fstream,
+    bool M_ReadElementData(std::ifstream * _fstream,
                            void * _data,
-                           METAIO_STL::streamoff _dataQuantity);
+                           std::streamoff _dataQuantity);
 
-    bool  M_WriteElements(METAIO_STREAM::ofstream * _fstream,
+    bool  M_WriteElements(std::ofstream * _fstream,
                           const void * _data,
-                          METAIO_STL::streamoff _dataQuantity);
+                          std::streamoff _dataQuantity);
 
-    bool  M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
+    bool  M_WriteElementsROI(std::ofstream * _fstream,
                              const void * _data,
-                             METAIO_STL::streampos _dataPos,
+                             std::streampos _dataPos,
                              int * _indexMin,
                              int* _indexMax);
 
-    bool  M_WriteElementData(METAIO_STREAM::ofstream * _fstream,
+    bool  M_WriteElementData(std::ofstream * _fstream,
                              const void * _data,
-                             METAIO_STL::streamoff _dataQuantity);
+                             std::streamoff _dataQuantity);
 
     bool M_FileExists(const char* filename) const;
 
     bool FileIsFullPath(const char* in_name) const;
 
-    METAIO_STL::string M_GetTagValue(const METAIO_STL::string & buffer,
+    std::string M_GetTagValue(const std::string & buffer,
                                      const char* tag) const;
 
   ////

--- a/src/metaLandmark.cxx
+++ b/src/metaLandmark.cxx
@@ -54,7 +54,7 @@ MetaLandmark::
 MetaLandmark()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark()" << std::endl;
   m_NPoints = 0;
   Clear();
 }
@@ -64,7 +64,7 @@ MetaLandmark::
 MetaLandmark(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaLandmark()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaLandmark()" << std::endl;
   m_NPoints = 0;
   Clear();
   Read(_headerName);
@@ -75,7 +75,7 @@ MetaLandmark::
 MetaLandmark(const MetaLandmark *_tube)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaLandmark()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaLandmark()" << std::endl;
   m_NPoints = 0;
   Clear();
   CopyInfo(_tube);
@@ -88,7 +88,7 @@ MetaLandmark::
 MetaLandmark(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark()" << std::endl;
   m_NPoints = 0;
   Clear();
 }
@@ -106,11 +106,11 @@ void MetaLandmark::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaLandmark::
@@ -150,9 +150,9 @@ NPoints() const
 void MetaLandmark::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark: Clear" << std::endl;
   MetaObject::Clear();
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark: Clear: m_NPoints" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark: Clear: m_NPoints" << std::endl;
   // Delete the list of pointers to tubes.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
@@ -178,7 +178,7 @@ M_Destroy()
 void MetaLandmark::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -255,15 +255,15 @@ M_SetupWriteFields()
 bool MetaLandmark::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaLandmark: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaLandmark: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLandmark: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLandmark: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 
@@ -328,17 +328,17 @@ M_Read()
   {
     int elementSize;
     MET_SizeOfType(m_ElementType, &elementSize);
-    METAIO_STL::streamsize readSize = m_NPoints*(m_NDims+4)*elementSize;
+    std::streamsize readSize = m_NPoints*(m_NDims+4)*elementSize;
 
     char* _data = new char[static_cast<size_t>(readSize)];
     m_ReadStream->read((char *)_data, readSize);
 
-    METAIO_STL::streamsize gc = m_ReadStream->gcount();
+    std::streamsize gc = m_ReadStream->gcount();
     if(gc != readSize)
     {
-      METAIO_STREAM::cout << "MetaLandmark: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaLandmark: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc << std::endl;
       delete [] _data;
       delete [] posDim;
       return false;
@@ -426,7 +426,7 @@ M_Write()
 
   if(!MetaObject::M_Write())
   {
-    METAIO_STREAM::cout << "MetaLandmark: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaLandmark: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
@@ -480,7 +480,7 @@ M_Write()
         *m_WriteStream << (*it)->m_Color[d] << " ";
       }
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
     }
   }

--- a/src/metaLandmark.h
+++ b/src/metaLandmark.h
@@ -67,7 +67,7 @@ class METAIO_EXPORT MetaLandmark : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<LandmarkPnt*> PointListType;
+   typedef std::list<LandmarkPnt*> PointListType;
     ////
     //
     // Constructors & Destructor

--- a/src/metaLine.cxx
+++ b/src/metaLine.cxx
@@ -67,7 +67,7 @@ MetaLine::
 MetaLine()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLine()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLine()" << std::endl;
   Clear();
 }
 
@@ -76,7 +76,7 @@ MetaLine::
 MetaLine(const char *_headerName)
 :MetaObject(_headerName)
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaLine()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaLine()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -86,7 +86,7 @@ MetaLine::
 MetaLine(const MetaLine *_line)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaLine()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaLine()" << std::endl;
   Clear();
   CopyInfo(_line);
 }
@@ -98,7 +98,7 @@ MetaLine::
 MetaLine(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLine()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLine()" << std::endl;
   Clear();
 }
 
@@ -115,11 +115,11 @@ void MetaLine::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaLine::
@@ -158,7 +158,7 @@ NPoints() const
 void MetaLine::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLine: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLine: Clear" << std::endl;
   MetaObject::Clear();
   m_NPoints = 0;
     // Delete the list of pointers to lines.
@@ -186,7 +186,7 @@ M_Destroy()
 void MetaLine::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLine: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLine: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -263,15 +263,15 @@ ElementType(MET_ValueEnumType _elementType)
 bool MetaLine::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLine: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLine: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaLine: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaLine: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaLine: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaLine: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 
@@ -318,9 +318,9 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
     {
-      METAIO_STREAM::cout << "MetaLine: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaLine: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc << std::endl;
       delete [] _data;
       return false;
     }
@@ -442,7 +442,7 @@ M_Write()
 {
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaLine: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaLine: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
@@ -516,7 +516,7 @@ M_Write()
         *m_WriteStream << (*it)->m_Color[d] << " ";
       }
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
     }
   }

--- a/src/metaLine.h
+++ b/src/metaLine.h
@@ -66,7 +66,7 @@ class METAIO_EXPORT MetaLine : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<LinePnt*> PointListType;
+   typedef std::list<LinePnt*> PointListType;
     ////
     //
     // Constructors & Destructor

--- a/src/metaMesh.cxx
+++ b/src/metaMesh.cxx
@@ -80,7 +80,7 @@ MetaMesh::
 MetaMesh()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
 
   for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
@@ -95,7 +95,7 @@ MetaMesh::
 MetaMesh(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaMesh()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
 
   for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
@@ -111,7 +111,7 @@ MetaMesh::
 MetaMesh(const MetaMesh *_mesh)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaMesh()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
   for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
     {
@@ -128,7 +128,7 @@ MetaMesh::
 MetaMesh(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh()" << std::endl;
   m_NPoints = 0;
   for(unsigned int i=0;i<MET_NUM_CELL_TYPES;i++)
     {
@@ -156,15 +156,15 @@ void MetaMesh::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_PointType, str);
-  METAIO_STREAM::cout << "PointType = " << str << METAIO_STREAM::endl;
+  std::cout << "PointType = " << str << std::endl;
   MET_TypeToString(m_PointDataType, str);
-  METAIO_STREAM::cout << "PointDataType = " << str << METAIO_STREAM::endl;
+  std::cout << "PointDataType = " << str << std::endl;
   MET_TypeToString(m_CellDataType, str);
-  METAIO_STREAM::cout << "CellDataType = " << str << METAIO_STREAM::endl;
+  std::cout << "CellDataType = " << str << std::endl;
 }
 
 void MetaMesh::
@@ -195,9 +195,9 @@ NCellLinks() const
 void MetaMesh::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh: Clear" << std::endl;
   MetaObject::Clear();
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh: Clear: m_NPoints" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh: Clear: m_NPoints" << std::endl;
 
   // Delete the list of pointers to points.
   PointListType::iterator it_pnt = m_PointList.begin();
@@ -279,7 +279,7 @@ M_Destroy()
 void MetaMesh::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -388,15 +388,15 @@ bool MetaMesh::
 M_Read()
 {
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaMesh: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaMesh: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaMesh: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaMesh: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 
@@ -449,10 +449,10 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
     {
-      METAIO_STREAM::cout << "MetaMesh: m_Read: Points not read completely"
-                          << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize
-                          << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaMesh: m_Read: Points not read completely"
+                          << std::endl;
+      std::cout << "   ideal = " << readSize
+                          << " : actual = " << gc << std::endl;
       delete [] _data;
       return false;
     }
@@ -592,8 +592,8 @@ M_Read()
 
    if(!MET_Read(*m_ReadStream, & m_Fields))
       {
-      METAIO_STREAM::cout << "MetaObject: Read: MET_Read Failed"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaObject: Read: MET_Read Failed"
+                          << std::endl;
       return false;
       }
 
@@ -628,10 +628,10 @@ M_Read()
       int gc = static_cast<int>(m_ReadStream->gcount());
       if(gc != readSize)
         {
-        METAIO_STREAM::cout << "MetaMesh: m_Read: Cells not read completely"
-                            << METAIO_STREAM::endl;
-        METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc
-                            << METAIO_STREAM::endl;
+        std::cout << "MetaMesh: m_Read: Cells not read completely"
+                            << std::endl;
+        std::cout << "   ideal = " << readSize << " : actual = " << gc
+                            << std::endl;
         delete [] _data;
         return false;
         }
@@ -700,7 +700,7 @@ M_Read()
     }
     }
 
-  METAIO_STL::streampos pos = m_ReadStream->tellg();
+  std::streampos pos = m_ReadStream->tellg();
 
   // Now reading the cell links
   MetaObject::ClearFields();
@@ -720,7 +720,7 @@ M_Read()
 
   if(!MET_Read(*m_ReadStream, & m_Fields,'=',false,false))
     {
-    METAIO_STREAM::cout << "MetaObject: Read: MET_Read Failed" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Read: MET_Read Failed" << std::endl;
     return false;
     }
 
@@ -750,9 +750,9 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
       {
-      METAIO_STREAM::cout << "MetaMesh: m_Read: Cell Link not read completely"
-        << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaMesh: m_Read: Cell Link not read completely"
+        << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc << std::endl;
       delete [] _data;
       return false;
       }
@@ -838,7 +838,7 @@ M_Read()
   if(m_NCellLinks == 0)
     {
     m_ReadStream->clear();
-    m_ReadStream->seekg(pos,METAIO_STREAM::ios::beg);
+    m_ReadStream->seekg(pos,std::ios::beg);
     }
   pos = m_ReadStream->tellg();
 
@@ -860,7 +860,7 @@ M_Read()
 
   if(!MET_Read(*m_ReadStream, & m_Fields,'=',false,false))
     {
-    METAIO_STREAM::cout << "MetaObject: Read: MET_Read Failed" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Read: MET_Read Failed" << std::endl;
     return false;
     }
 
@@ -883,9 +883,9 @@ M_Read()
   unsigned int gc = static_cast<unsigned int>(m_ReadStream->gcount());
   if(gc != pointDataSize)
     {
-    METAIO_STREAM::cout << "MetaMesh: m_Read: PointData not read completely"
-              << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "   ideal = " << pointDataSize << " : actual = " << gc << METAIO_STREAM::endl;
+    std::cout << "MetaMesh: m_Read: PointData not read completely"
+              << std::endl;
+    std::cout << "   ideal = " << pointDataSize << " : actual = " << gc << std::endl;
     delete [] _data;
     return false;
     }
@@ -987,8 +987,8 @@ M_Read()
       }
     else  // assume double
       {
-      METAIO_STREAM::cerr << "Warning: Mesh point data type not known - assuming double"
-                << METAIO_STREAM::endl;
+      std::cerr << "Warning: Mesh point data type not known - assuming double"
+                << std::endl;
       double val = alignedBuffer.doublefloatingpoint;
       pd = new MeshData<double>();
       MET_SwapByteIfSystemMSB(&val,MET_DOUBLE);
@@ -1003,7 +1003,7 @@ M_Read()
   if(m_NPointData == 0)
     {
     m_ReadStream->clear();
-    m_ReadStream->seekg(pos,METAIO_STREAM::ios::beg);
+    m_ReadStream->seekg(pos,std::ios::beg);
     }
   pos = m_ReadStream->tellg();
 
@@ -1025,7 +1025,7 @@ M_Read()
 
   if(!MET_Read(*m_ReadStream, & m_Fields,'=',false,false))
     {
-    METAIO_STREAM::cout << "MetaObject: Read: MET_Read Failed" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Read: MET_Read Failed" << std::endl;
     return false;
     }
 
@@ -1049,9 +1049,9 @@ M_Read()
   unsigned int gcCell = static_cast<unsigned int>(m_ReadStream->gcount());
   if(gcCell != cellDataSize)
     {
-    METAIO_STREAM::cout << "MetaMesh: m_Read: data not read completely"
-              << METAIO_STREAM::endl;
-    METAIO_STREAM::cout << "   ideal = " << cellDataSize << " : actual = " << gcCell << METAIO_STREAM::endl;
+    std::cout << "MetaMesh: m_Read: data not read completely"
+              << std::endl;
+    std::cout << "   ideal = " << cellDataSize << " : actual = " << gcCell << std::endl;
     delete [] _data;
     delete [] _celldata;
     return false;
@@ -1152,8 +1152,8 @@ M_Read()
       }
     else
       {
-      METAIO_STREAM::cerr << "Warning: Mesh point data type not known - assuming double"
-        << METAIO_STREAM::endl;
+      std::cerr << "Warning: Mesh point data type not known - assuming double"
+        << std::endl;
       double val = alignedBuffer.doublefloatingpoint;
       cd = new MeshData<double>();
       MET_SwapByteIfSystemMSB(&val,MET_DOUBLE);
@@ -1169,7 +1169,7 @@ M_Read()
   if(m_NCellData == 0)
     {
     m_ReadStream->clear();
-    m_ReadStream->seekg(pos,METAIO_STREAM::ios::beg);
+    m_ReadStream->seekg(pos,std::ios::beg);
     }
 
   return true;
@@ -1180,7 +1180,7 @@ M_Write()
 {
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaMesh: M_Write: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaMesh: M_Write: Error parsing file" << std::endl;
     return false;
     }
 
@@ -1225,7 +1225,7 @@ M_Write()
         {
         *m_WriteStream << (*it)->m_X[d] << " ";
         }
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }
@@ -1258,7 +1258,7 @@ M_Write()
 
       if(!MetaObject::M_Write())
         {
-        METAIO_STREAM::cout << "MetaMesh: M_Write: Error parsing file" << METAIO_STREAM::endl;
+        std::cout << "MetaMesh: M_Write: Error parsing file" << std::endl;
         return false;
         }
 
@@ -1303,7 +1303,7 @@ M_Write()
             *m_WriteStream << (*it)->m_PointsId[d] << " ";
             }
 
-          *m_WriteStream << METAIO_STREAM::endl;
+          *m_WriteStream << std::endl;
           ++it;
           }
         }
@@ -1343,7 +1343,7 @@ M_Write()
 
     if(!MetaObject::M_Write())
       {
-      METAIO_STREAM::cout << "MetaMesh: M_Write: Error parsing file" << METAIO_STREAM::endl;
+      std::cout << "MetaMesh: M_Write: Error parsing file" << std::endl;
       return false;
       }
 
@@ -1364,8 +1364,8 @@ M_Write()
         MET_SwapByteIfSystemMSB(&linkSize,MET_INT);
         MET_DoubleToValue((double)linkSize,MET_INT,data,j++);
 
-        METAIO_STL::list<int>::const_iterator it2 = (*it)->m_Links.begin();
-        METAIO_STL::list<int>::const_iterator it2End = (*it)->m_Links.end();
+        std::list<int>::const_iterator it2 = (*it)->m_Links.begin();
+        std::list<int>::const_iterator it2End = (*it)->m_Links.end();
         while(it2 != it2End)
           {
           int links = (*it2);
@@ -1388,14 +1388,14 @@ M_Write()
         {
         *m_WriteStream << (*it)->m_Id << " ";
         *m_WriteStream << (*it)->m_Links.size() << " ";
-        METAIO_STL::list<int>::const_iterator it2 = (*it)->m_Links.begin();
-        METAIO_STL::list<int>::const_iterator it2End = (*it)->m_Links.end();
+        std::list<int>::const_iterator it2 = (*it)->m_Links.begin();
+        std::list<int>::const_iterator it2End = (*it)->m_Links.end();
         while(it2 != it2End)
           {
           *m_WriteStream << (*it2) << " ";
           ++it2;
           }
-        *m_WriteStream << METAIO_STREAM::endl;
+        *m_WriteStream << std::endl;
         ++it;
         }
       }
@@ -1431,8 +1431,8 @@ M_Write()
 
     if(!MetaObject::M_Write())
       {
-      METAIO_STREAM::cout << "MetaMesh: M_Write: Error parsing file"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaMesh: M_Write: Error parsing file"
+                          << std::endl;
       return false;
       }
 
@@ -1480,8 +1480,8 @@ M_Write()
 
     if(!MetaObject::M_Write())
       {
-      METAIO_STREAM::cout << "MetaMesh: M_Write: Error parsing file"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaMesh: M_Write: Error parsing file"
+                          << std::endl;
       return false;
       }
 

--- a/src/metaMesh.h
+++ b/src/metaMesh.h
@@ -108,7 +108,7 @@ public:
     }
 
   int m_Id; // id of the cell link
-  METAIO_STL::list<int> m_Links;
+  std::list<int> m_Links;
 };
 
 /** Define a mesh point data */
@@ -124,15 +124,15 @@ public:
     {
     }
 
-  virtual void Write( METAIO_STREAM::ofstream* stream) = 0;
+  virtual void Write( std::ofstream* stream) = 0;
   virtual unsigned int GetSize(void) = 0;
   virtual MET_ValueEnumType GetMetaType() = 0;
   int m_Id;
 
 protected:
 
-  METAIO_STREAM::ifstream* m_ReadStream;
-  METAIO_STREAM::ofstream* m_WriteStream;
+  std::ifstream* m_ReadStream;
+  std::ofstream* m_WriteStream;
 
 };
 
@@ -150,7 +150,7 @@ public:
     return MET_GetPixelType(typeid(TElementType));
     }
 
-  void Write( METAIO_STREAM::ofstream* stream) override
+  void Write( std::ofstream* stream) override
     {
     //char* id = new char[sizeof(int)];
     // The file is written as LSB by default
@@ -188,11 +188,11 @@ class METAIO_EXPORT MetaMesh : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<MeshPoint*> PointListType;
-   typedef METAIO_STL::list<MeshCell*>  CellListType;
-   typedef METAIO_STL::list<MeshCellLink*>  CellLinkListType;
-   typedef METAIO_STL::list<MeshDataBase*> PointDataListType;
-   typedef METAIO_STL::list<MeshDataBase*> CellDataListType;
+   typedef std::list<MeshPoint*> PointListType;
+   typedef std::list<MeshCell*>  CellListType;
+   typedef std::list<MeshCellLink*>  CellLinkListType;
+   typedef std::list<MeshDataBase*> PointDataListType;
+   typedef std::list<MeshDataBase*> CellDataListType;
 
     ////
     //

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -101,7 +101,7 @@ ClearFields()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject:ClearFields" << METAIO_STREAM::endl;
+    std::cout << "MetaObject:ClearFields" << std::endl;
     }
 
   FieldsContainerType::iterator  it  = m_Fields.begin();
@@ -239,8 +239,8 @@ CopyInfo(const MetaObject * _object)
   {
   if(NDims() != _object->NDims())
     {
-    METAIO_STREAM::cout << "MetaObject: CopyInfo: Warning: NDims not same size"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaObject: CopyInfo: Warning: NDims not same size"
+                        << std::endl;
     }
 
   FileName(_object->FileName());
@@ -266,7 +266,7 @@ Read(const char *_fileName)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: Read" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Read" << std::endl;
     }
 
   if(_fileName != nullptr)
@@ -274,13 +274,13 @@ Read(const char *_fileName)
     strcpy(m_FileName, _fileName);
     }
 
-  METAIO_STREAM::ifstream * tmpReadStream = new METAIO_STREAM::ifstream;
+  std::ifstream * tmpReadStream = new std::ifstream;
 
 #ifdef __sgi
-  tmpReadStream->open(m_FileName, METAIO_STREAM::ios::in);
+  tmpReadStream->open(m_FileName, std::ios::in);
 #else
-  tmpReadStream->open(m_FileName, METAIO_STREAM::ios::binary |
-                                  METAIO_STREAM::ios::in);
+  tmpReadStream->open(m_FileName, std::ios::binary |
+                                  std::ios::in);
 #endif
 
   if(!tmpReadStream->rdbuf()->is_open())
@@ -305,11 +305,11 @@ Read(const char *_fileName)
 
 
 bool MetaObject::
-ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream)
+ReadStream(int _nDims, std::ifstream * _stream)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: ReadStream" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: ReadStream" << std::endl;
     }
 
   M_Destroy();
@@ -351,17 +351,17 @@ Write(const char *_fileName)
 
   if(!m_WriteStream)
     {
-    m_WriteStream = new METAIO_STREAM::ofstream;
+    m_WriteStream = new std::ofstream;
     }
 
 #ifdef __sgi
   // Create the file. This is required on some older sgi's
-  METAIO_STREAM::ofstream tFile(m_FileName, METAIO_STREAM::ios::out);
+  std::ofstream tFile(m_FileName, std::ios::out);
   tFile.close();
-  m_WriteStream->open(m_FileName, METAIO_STREAM::ios::out);
+  m_WriteStream->open(m_FileName, std::ios::out);
 #else
-  m_WriteStream->open(m_FileName, METAIO_STREAM::ios::binary |
-                                  METAIO_STREAM::ios::out);
+  m_WriteStream->open(m_FileName, std::ios::binary |
+                                  std::ios::out);
 #endif
 
   if(!m_WriteStream->rdbuf()->is_open())
@@ -385,89 +385,89 @@ PrintInfo() const
   {
   int i, j;
 
-  METAIO_STREAM::cout << "FileName = _" << m_FileName << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Comment = _" << m_Comment << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "ObjectType = _" << m_ObjectTypeName << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "ObjectSubType = _" << m_ObjectSubTypeName << "_"
-                      << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NDims = " << m_NDims << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "Name = " << m_Name << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "ID = " << m_ID << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "ParentID = " << m_ParentID << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "AcquisitionDate = " << m_AcquisitionDate << METAIO_STREAM::endl;
+  std::cout << "FileName = _" << m_FileName << "_"
+                      << std::endl;
+  std::cout << "Comment = _" << m_Comment << "_"
+                      << std::endl;
+  std::cout << "ObjectType = _" << m_ObjectTypeName << "_"
+                      << std::endl;
+  std::cout << "ObjectSubType = _" << m_ObjectSubTypeName << "_"
+                      << std::endl;
+  std::cout << "NDims = " << m_NDims << std::endl;
+  std::cout << "Name = " << m_Name << std::endl;
+  std::cout << "ID = " << m_ID << std::endl;
+  std::cout << "ParentID = " << m_ParentID << std::endl;
+  std::cout << "AcquisitionDate = " << m_AcquisitionDate << std::endl;
   if(m_CompressedData)
     {
-    METAIO_STREAM::cout << "CompressedData = True" << METAIO_STREAM::endl;
+    std::cout << "CompressedData = True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "CompressedData = False" << METAIO_STREAM::endl;
+    std::cout << "CompressedData = False" << std::endl;
     }
-  METAIO_STREAM::cout << "m_CompressedDataSize = " << m_CompressedDataSize
-                      << METAIO_STREAM::endl;
+  std::cout << "m_CompressedDataSize = " << m_CompressedDataSize
+                      << std::endl;
   if(m_BinaryData)
     {
-    METAIO_STREAM::cout << "BinaryData = True" << METAIO_STREAM::endl;
+    std::cout << "BinaryData = True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "BinaryData = False" << METAIO_STREAM::endl;
+    std::cout << "BinaryData = False" << std::endl;
     }
   if(m_BinaryData && m_BinaryDataByteOrderMSB)
     {
-    METAIO_STREAM::cout << "BinaryDataByteOrderMSB = True"
-                        << METAIO_STREAM::endl;
+    std::cout << "BinaryDataByteOrderMSB = True"
+                        << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "BinaryDataByteOrderMSB = False"
-                        << METAIO_STREAM::endl;
+    std::cout << "BinaryDataByteOrderMSB = False"
+                        << std::endl;
     }
-  METAIO_STREAM::cout << "Color = " ;
+  std::cout << "Color = " ;
   for(i=0; i<4; i++)
     {
-    METAIO_STREAM::cout << m_Color[i] << " ";
+    std::cout << m_Color[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
-  METAIO_STREAM::cout << "Offset = ";
+  std::cout << "Offset = ";
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_Offset[i] << " ";
+    std::cout << m_Offset[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
-  METAIO_STREAM::cout << "TransformMatrix = ";
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << "TransformMatrix = ";
+  std::cout << std::endl;
   for(i=0; i<m_NDims; i++)
     {
     for(j=0; j<m_NDims; j++)
       {
-      METAIO_STREAM::cout << m_TransformMatrix[i*m_NDims+j] << " ";
+      std::cout << m_TransformMatrix[i*m_NDims+j] << " ";
       }
-    METAIO_STREAM::cout << METAIO_STREAM::endl;
+    std::cout << std::endl;
     }
 
-  METAIO_STREAM::cout << "CenterOfRotation = ";
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << "CenterOfRotation = ";
+  std::cout << std::endl;
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_CenterOfRotation[i] << " ";
+    std::cout << m_CenterOfRotation[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
-  METAIO_STREAM::cout << "ElementSpacing = ";
+  std::cout << "ElementSpacing = ";
   for(i=0; i<m_NDims; i++)
     {
-    METAIO_STREAM::cout << m_ElementSpacing[i] << " ";
+    std::cout << m_ElementSpacing[i] << " ";
     }
-  METAIO_STREAM::cout << METAIO_STREAM::endl;
+  std::cout << std::endl;
 
-  METAIO_STREAM::cout << "DistanceUnits = " << this->DistanceUnitsName()
-                      << METAIO_STREAM::endl;
+  std::cout << "DistanceUnits = " << this->DistanceUnitsName()
+                      << std::endl;
 
   // Print User's fields :
   FieldsContainerType::const_iterator  itw = m_UserDefinedWriteFields.begin();
@@ -521,17 +521,17 @@ PrintInfo() const
       }
     else if((*it)->type == MET_FLOAT_MATRIX)
       {
-      METAIO_STREAM::cout << METAIO_STREAM::endl;
+      std::cout << std::endl;
       for(i=0; i<(*it)->length*(*it)->length; i++)
         {
         printf("%f ",(*it)->value[i]);
         if(i==(*it)->length-1)
           {
-          METAIO_STREAM::cout << METAIO_STREAM::endl;
+          std::cout << std::endl;
           }
         }
       }
-    METAIO_STREAM::cout << METAIO_STREAM::endl;
+    std::cout << std::endl;
 
     ++itw;
     ++itr;
@@ -1057,7 +1057,7 @@ Clear()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: Clear()" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Clear()" << std::endl;
     }
   strcpy(m_Comment, "");
   strcpy(m_ObjectTypeName, "Object");
@@ -1086,8 +1086,8 @@ Clear()
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: Clear: m_NDims=" << m_NDims
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Clear: m_NDims=" << m_NDims
+                        << std::endl;
     }
   int i;
   for(i=0; i<10; i++)
@@ -1096,14 +1096,14 @@ Clear()
     m_AnatomicalOrientation[i] = MET_ORIENTATION_UNKNOWN;
     }
 /*
-  METAIO_STL::vector<MET_FieldRecordType *>::iterator fieldIter;
+  std::vector<MET_FieldRecordType *>::iterator fieldIter;
   for(fieldIter=m_Fields.begin(); fieldIter!=m_Fields.end(); fieldIter++)
     {
-    if(META_DEBUG) METAIO_STREAM::cout << "field = " << (*fieldIter)->name << METAIO_STREAM::endl;
+    if(META_DEBUG) std::cout << "field = " << (*fieldIter)->name << std::endl;
     MET_FieldRecordType* field = *fieldIter;
     delete field;
     field = NULL;
-    if(META_DEBUG) METAIO_STREAM::cout << " has been deleted." << METAIO_STREAM::endl;
+    if(META_DEBUG) std::cout << " has been deleted." << std::endl;
     }
   m_Fields.clear();*/
   this->ClearFields();
@@ -1114,28 +1114,28 @@ InitializeEssential(int _nDims)
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: Initialize" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Initialize" << std::endl;
     }
 
   M_Destroy();
 
   if(_nDims > 10)
     {
-    METAIO_STREAM::cout
+    std::cout
       << "MetaObject: Initialize: Warning: Number of dimensions limited to 10"
-      << METAIO_STREAM::endl
+      << std::endl
       << "Resetting number of dimensions to 10"
-      << METAIO_STREAM::endl;
+      << std::endl;
     _nDims = 10;
     }
 
   if(_nDims < 0)
     {
-    METAIO_STREAM::cout
+    std::cout
       << "MetaObject: Initialize: Warning: Number of dimensions must be >= 0"
-      << METAIO_STREAM::endl
+      << std::endl
       << "Resetting number of dimensions to 0"
-      << METAIO_STREAM::endl;
+      << std::endl;
     _nDims = 0;
     }
 
@@ -1149,7 +1149,7 @@ M_Destroy()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: Destroy" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Destroy" << std::endl;
     }
   }
 
@@ -1159,8 +1159,8 @@ M_SetupReadFields()
   this->ClearFields();
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: M_SetupReadFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaObject: M_SetupReadFields"
+                        << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -1295,16 +1295,16 @@ M_SetupWriteFields()
   {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: M_SetupWriteFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaObject: M_SetupWriteFields"
+                        << std::endl;
     }
 
   this->ClearFields();
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: M_SetupWriteFields: Creating Fields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaObject: M_SetupWriteFields: Creating Fields"
+                        << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -1503,8 +1503,8 @@ M_Read()
   if(!MET_Read(*m_ReadStream, &m_Fields, '=', false, true,
      &m_AdditionalReadFields))
     {
-    METAIO_STREAM::cerr << "MetaObject: Read: MET_Read Failed"
-                        << METAIO_STREAM::endl;
+    std::cerr << "MetaObject: Read: MET_Read Failed"
+                        << std::endl;
     return false;
     }
 
@@ -1751,9 +1751,9 @@ M_Read()
         m_ElementSpacing[i] = mF->value[i];
         if (META_DEBUG)
           {
-          METAIO_STREAM::cout << "metaObject: M_Read: elementSpacing["
+          std::cout << "metaObject: M_Read: elementSpacing["
                               << i << "] = "
-                              << m_ElementSpacing[i] << METAIO_STREAM::endl;
+                              << m_ElementSpacing[i] << std::endl;
           }
         }
       }
@@ -1764,9 +1764,9 @@ M_Read()
         m_ElementSpacing[i] = 1;
         if (META_DEBUG)
           {
-          METAIO_STREAM::cout << "metaObject: M_Read: elementSpacing["
+          std::cout << "metaObject: M_Read: elementSpacing["
                               << i << "] = "
-                              << m_ElementSpacing[i] << METAIO_STREAM::endl;
+                              << m_ElementSpacing[i] << std::endl;
           }
         }
       }
@@ -1809,8 +1809,8 @@ M_Write()
 
   if(!MET_Write(*m_WriteStream, & m_Fields))
     {
-    METAIO_STREAM::cerr << "MetaObject: Write: MET_Write Failed"
-                        << METAIO_STREAM::endl;
+    std::cerr << "MetaObject: Write: MET_Write Failed"
+                        << std::endl;
     return false;
     }
 
@@ -1823,7 +1823,7 @@ bool MetaObject
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaObject: Append" << METAIO_STREAM::endl;
+    std::cout << "MetaObject: Append" << std::endl;
     }
 
   if(_headName != nullptr)
@@ -1835,23 +1835,23 @@ bool MetaObject
 
   if(!m_WriteStream)
     {
-    m_WriteStream = new METAIO_STREAM::ofstream;
+    m_WriteStream = new std::ofstream;
     }
 
 #ifdef __sgi
-  m_WriteStream->open(m_FileName, METAIO_STREAM::ios::out
-                                  | METAIO_STREAM::ios::in);
+  m_WriteStream->open(m_FileName, std::ios::out
+                                  | std::ios::in);
   if(!m_WriteStream->rdbuf()->is_open())
     {
     delete m_WriteStream;
     m_WriteStream = 0;
     return false;
     }
-  m_WriteStream->seekp(0,METAIO_STREAM::ios::end);
+  m_WriteStream->seekp(0,std::ios::end);
 #else
-  m_WriteStream->open(m_FileName, METAIO_STREAM::ios::binary
-                                  | METAIO_STREAM::ios::out
-                                  | METAIO_STREAM::ios::app);
+  m_WriteStream->open(m_FileName, std::ios::binary
+                                  | std::ios::out
+                                  | std::ios::app);
   if(!m_WriteStream->rdbuf()->is_open())
     {
     delete m_WriteStream;
@@ -1963,7 +1963,7 @@ void MetaObject::M_PrepareNewReadStream()
     }
   else
     {
-    m_ReadStream = new METAIO_STREAM::ifstream;
+    m_ReadStream = new std::ifstream;
     }
 }
 

--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -35,10 +35,10 @@ class METAIO_EXPORT MetaObject
   ////
   protected:
 
-      typedef METAIO_STL::vector<MET_FieldRecordType *> FieldsContainerType;
+      typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
-      METAIO_STREAM::ifstream * m_ReadStream;
-      METAIO_STREAM::ofstream * m_WriteStream;
+      std::ifstream * m_ReadStream;
+      std::ofstream * m_WriteStream;
 
       FieldsContainerType m_Fields;
       FieldsContainerType m_UserDefinedWriteFields;
@@ -79,7 +79,7 @@ class METAIO_EXPORT MetaObject
 
       bool  m_BinaryDataByteOrderMSB;
 
-      METAIO_STL::streamoff m_CompressedDataSize;
+      std::streamoff m_CompressedDataSize;
       // Used internally to set if the dataSize should be written
       bool m_WriteCompressedDataSize;
       bool m_CompressedData;
@@ -125,7 +125,7 @@ class METAIO_EXPORT MetaObject
 
       bool  Read(const char * _fileName=NULL);
 
-      bool  ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream);
+      bool  ReadStream(int _nDims, std::ifstream * _stream);
 
       bool  Write(const char * _fileName=NULL);
 

--- a/src/metaOutput.cxx
+++ b/src/metaOutput.cxx
@@ -39,13 +39,13 @@ namespace METAIO_NAMESPACE {
 
 
 /** Stolen from kwsys */
-static METAIO_STL::string GetCurrentDateTime(const char* format)
+static std::string GetCurrentDateTime(const char* format)
 {
   char buf[1024];
   time_t t;
   time(&t);
   strftime(buf, sizeof(buf), format, localtime(&t));
-  return METAIO_STL::string(buf);
+  return std::string(buf);
 }
 
 
@@ -78,7 +78,7 @@ Disable()
 }
 
 void MetaOutputStream::
-SetStdStream(METAIO_STREAM::ostream * stream)
+SetStdStream(std::ostream * stream)
 {
   m_StdStream = stream;
   m_IsStdStream = true;
@@ -90,14 +90,14 @@ IsStdStream()
   return m_IsStdStream;
 }
 
-METAIO_STREAM::ostream *
+std::ostream *
 MetaOutputStream::
 GetStdStream()
 {
   return m_StdStream;
 }
 
-METAIO_STL::string
+std::string
 MetaOutputStream::
 GetName() const
 {
@@ -160,10 +160,10 @@ Open()
 {
   MetaOutputStream::Open();
 #ifdef __sgi
-  m_FileStream.open(m_FileName.c_str(), METAIO_STREAM::ios::out);
+  m_FileStream.open(m_FileName.c_str(), std::ios::out);
 #else
-  m_FileStream.open(m_FileName.c_str(), METAIO_STREAM::ios::binary
-                                        | METAIO_STREAM::ios::out);
+  m_FileStream.open(m_FileName.c_str(), std::ios::binary
+                                        | std::ios::out);
 #endif
   if( m_FileStream.rdbuf()->is_open() )
     {
@@ -184,7 +184,7 @@ Close()
   return true;
 }
 
-METAIO_STL::string
+std::string
 MetaFileOutputStream::
 GetFileName()
 {
@@ -213,12 +213,12 @@ MetaOutput::
 
  /** Add a field */
 bool MetaOutput::
-AddField(METAIO_STL::string name,
-         METAIO_STL::string description,
+AddField(std::string name,
+         std::string description,
          TypeEnumType type,
-         METAIO_STL::string value,
-         METAIO_STL::string rangeMin,
-         METAIO_STL::string rangeMax
+         std::string value,
+         std::string rangeMin,
+         std::string rangeMax
          )
 {
   Field field;
@@ -234,11 +234,11 @@ AddField(METAIO_STL::string name,
 
  /** Add a float field */
 bool MetaOutput::
-AddFloatField(METAIO_STL::string name,
-              METAIO_STL::string description,
+AddFloatField(std::string name,
+              std::string description,
               float value,
-              METAIO_STL::string rangeMin,
-              METAIO_STL::string rangeMax
+              std::string rangeMin,
+              std::string rangeMax
               )
 {
   char val[20];
@@ -249,11 +249,11 @@ AddFloatField(METAIO_STL::string name,
 
 /** Add a int field */
 bool MetaOutput::
-AddIntField(METAIO_STL::string name,
-            METAIO_STL::string description,
+AddIntField(std::string name,
+            std::string description,
             int value,
-            METAIO_STL::string rangeMin,
-            METAIO_STL::string rangeMax
+            std::string rangeMin,
+            std::string rangeMax
             )
 {
   char val[10];
@@ -263,8 +263,8 @@ AddIntField(METAIO_STL::string name,
 }
 
 /** Add list field */
-bool MetaOutput::AddListField(METAIO_STL::string name,
-                              METAIO_STL::string description,
+bool MetaOutput::AddListField(std::string name,
+                              std::string description,
                               ListType list)
 {
   Field field;
@@ -298,7 +298,7 @@ SetMetaCommand(MetaCommand* metaCommand)
 }
 
 /** Get the username */
-METAIO_STL::string MetaOutput::
+std::string MetaOutput::
 GetUsername()
 {
 #if defined (_WIN32) && !defined(__CYGWIN__)
@@ -306,19 +306,19 @@ GetUsername()
     DWORD size = sizeof(buf);
     buf[0] = '\0';
     GetUserName( buf, &size);
-    return  METAIO_STL::string(buf);
+    return  std::string(buf);
 #else  // not _WIN32
     struct passwd *pw = getpwuid(getuid());
     if ( pw == nullptr )
       {
-        METAIO_STREAM::cout << "getpwuid() failed " << METAIO_STREAM::endl;
+        std::cout << "getpwuid() failed " << std::endl;
         return "";
       }
     return pw->pw_name;
 #endif // not _WIN32
 }
 
-METAIO_STL::string MetaOutput::
+std::string MetaOutput::
 GetHostname()
 {
 #if defined (_WIN32) && !defined(__CYGWIN__)
@@ -331,11 +331,11 @@ GetHostname()
 #endif
   char nameBuffer[1024];
   gethostname(nameBuffer, 1024);
-  METAIO_STL::string hostName(nameBuffer);
+  std::string hostName(nameBuffer);
   return hostName;
 }
 
-METAIO_STL::string MetaOutput::GetHostip()
+std::string MetaOutput::GetHostip()
 {
   #if defined (_WIN32) && !defined(__CYGWIN__)
     WSADATA    WsaData;
@@ -357,7 +357,7 @@ METAIO_STL::string MetaOutput::GetHostip()
     address++;
   }
 
-  METAIO_STL::string m_ip = "";
+  std::string m_ip = "";
   if (m_numaddrs != 0)
   {
     memcpy(&addr, phe->h_addr_list[m_numaddrs-1], sizeof(struct in_addr));
@@ -368,7 +368,7 @@ METAIO_STL::string MetaOutput::GetHostip()
 }
 
 /** Return the string representation of a type */
-METAIO_STL::string MetaOutput::TypeToString(TypeEnumType type)
+std::string MetaOutput::TypeToString(TypeEnumType type)
 {
   switch(type)
     {
@@ -390,14 +390,14 @@ METAIO_STL::string MetaOutput::TypeToString(TypeEnumType type)
     }
 }
 /** Private function to fill in the buffer */
-METAIO_STL::string MetaOutput::GenerateXML(const char* filename)
+std::string MetaOutput::GenerateXML(const char* filename)
 {
-  METAIO_STL::string buffer;
+  std::string buffer;
   buffer = "<?xml version=\"1.0\"?>\n";
   buffer += "<MetaOutputFile ";
   if(filename)
     {
-    METAIO_STL::string filenamestr = filename;
+    std::string filenamestr = filename;
     buffer += "name=\"" +filenamestr+"\"";
     }
   buffer += " version=\""+m_CurrentVersion+"\">\n";
@@ -427,7 +427,7 @@ METAIO_STL::string MetaOutput::GenerateXML(const char* filename)
       continue;
       }
 
-    typedef METAIO_STL::vector<MetaCommand::Field> CmdFieldVector;
+    typedef std::vector<MetaCommand::Field> CmdFieldVector;
     CmdFieldVector::const_iterator itField = (*itInput).fields.begin();
     CmdFieldVector::const_iterator itFieldEnd = (*itInput).fields.end();
     while(itField != itFieldEnd)
@@ -485,7 +485,7 @@ METAIO_STL::string MetaOutput::GenerateXML(const char* filename)
     buffer += " type=\""+ this->TypeToString((*itOutput).type) + "\"";
 
     unsigned int index = 0;
-    typedef METAIO_STL::vector<METAIO_STL::string> VectorType;
+    typedef std::vector<std::string> VectorType;
     VectorType::const_iterator itValue = (*itOutput).value.begin();
     while(itValue != (*itOutput).value.end())
       {
@@ -523,20 +523,20 @@ void MetaOutput::Write()
 {
   if(m_MetaCommand && m_MetaCommand->GetOptionWasSet("GenerateXMLMetaOutput"))
     {
-    METAIO_STREAM::cout << this->GenerateXML().c_str() << METAIO_STREAM::endl;
+    std::cout << this->GenerateXML().c_str() << std::endl;
     }
   if(m_MetaCommand && m_MetaCommand->GetOptionWasSet("GenerateXMLFile"))
     {
     //this->GenerateXML();
-    METAIO_STL::string filename = m_MetaCommand
+    std::string filename = m_MetaCommand
                                   ->GetValueAsString("GenerateXMLFile");
-    METAIO_STREAM::ofstream fileStream;
+    std::ofstream fileStream;
 
 #ifdef __sgi
-    fileStream.open(filename.c_str(), METAIO_STREAM::ios::out);
+    fileStream.open(filename.c_str(), std::ios::out);
 #else
-    fileStream.open(filename.c_str(), METAIO_STREAM::ios::binary
-                                      | METAIO_STREAM::ios::out);
+    fileStream.open(filename.c_str(), std::ios::binary
+                                      | std::ios::out);
 #endif
 
     if(fileStream.rdbuf()->is_open())
@@ -564,8 +564,8 @@ void MetaOutput::Write()
 
     if(!(*itStream)->Open())
       {
-      METAIO_STREAM::cout << "MetaOutput ERROR: cannot open stream"
-                       << METAIO_STREAM::endl;
+      std::cout << "MetaOutput ERROR: cannot open stream"
+                       << std::endl;
       return;
       }
 
@@ -575,7 +575,7 @@ void MetaOutput::Write()
       {
       if(dynamic_cast<MetaFileOutputStream*>(*itStream))
         {
-        METAIO_STL::string filename = ((MetaFileOutputStream*)(*itStream))
+        std::string filename = ((MetaFileOutputStream*)(*itStream))
                                       ->GetFileName().c_str();
         (*itStream)->Write(this->GenerateXML(filename.c_str()).c_str());
         }
@@ -588,8 +588,8 @@ void MetaOutput::Write()
 
     if(!(*itStream)->Close())
       {
-      METAIO_STREAM::cout << "MetaOutput ERROR: cannot close stream"
-                          << METAIO_STREAM::endl;
+      std::cout << "MetaOutput ERROR: cannot close stream"
+                          << std::endl;
       return;
       }
     ++itStream;
@@ -597,7 +597,7 @@ void MetaOutput::Write()
 }
 
 /** Add a stream */
-void MetaOutput::AddStream(const char* name,METAIO_STREAM::ostream & stdstream)
+void MetaOutput::AddStream(const char* name,std::ostream & stdstream)
 {
   MetaOutputStream* stream = new MetaOutputStream;
   stream->SetName(name);

--- a/src/metaOutput.h
+++ b/src/metaOutput.h
@@ -37,15 +37,15 @@ class MetaOutputStream
     virtual ~MetaOutputStream() {}
 
     void                     SetName(const char* name);
-    METAIO_STL::string       GetName() const;
+    std::string       GetName() const;
 
     void                     Enable();
     bool                     IsEnable() const;
     void                     Disable();
 
-    void                     SetStdStream(METAIO_STREAM::ostream * stream);
+    void                     SetStdStream(std::ostream * stream);
     bool                     IsStdStream();
-    METAIO_STREAM::ostream * GetStdStream();
+    std::ostream * GetStdStream();
 
     virtual bool             Open();
     virtual bool             Close();
@@ -56,11 +56,11 @@ class MetaOutputStream
 
   protected:
 
-    METAIO_STREAM::ostream * m_StdStream;
+    std::ostream * m_StdStream;
     bool                     m_IsStdStream;
     bool                     m_Enable;
     bool                     m_IsOpen;
-    METAIO_STL::string       m_Name;
+    std::string       m_Name;
     void*                    m_MetaOutput;
 
 };
@@ -75,12 +75,12 @@ class MetaFileOutputStream : public MetaOutputStream
     bool Open() override;
     bool Close() override;
 
-    METAIO_STL::string GetFileName();
+    std::string GetFileName();
 
   private:
 
-    METAIO_STL::string      m_FileName;
-    METAIO_STREAM::ofstream m_FileStream;
+    std::string      m_FileName;
+    std::ofstream m_FileStream;
 };
 
 class METAIO_EXPORT MetaOutput
@@ -90,46 +90,46 @@ class METAIO_EXPORT MetaOutput
     typedef enum {INT,FLOAT,CHAR,STRING,LIST,FLAG,BOOL} TypeEnumType;
 
     struct Field{
-      METAIO_STL::string  name;
-      METAIO_STL::string  description;
-      METAIO_STL::vector<METAIO_STL::string>  value;
+      std::string  name;
+      std::string  description;
+      std::vector<std::string>  value;
       TypeEnumType type;
-      METAIO_STL::string  rangeMin;
-      METAIO_STL::string  rangeMax;
+      std::string  rangeMin;
+      std::string  rangeMax;
       };
 
-    typedef METAIO_STL::vector<Field>              FieldVector;
-    typedef METAIO_STL::vector<MetaOutputStream*>  StreamVector;
-    typedef METAIO_STL::list< METAIO_STL::string > ListType;
+    typedef std::vector<Field>              FieldVector;
+    typedef std::vector<MetaOutputStream*>  StreamVector;
+    typedef std::list< std::string > ListType;
 
     MetaOutput();
     ~MetaOutput();
 
     /** Add a field */
-    bool AddField(METAIO_STL::string name,
-                  METAIO_STL::string description,
+    bool AddField(std::string name,
+                  std::string description,
                   TypeEnumType type,
-                  METAIO_STL::string value,
-                  METAIO_STL::string rangeMin = "",
-                  METAIO_STL::string rangeMax = ""
+                  std::string value,
+                  std::string rangeMin = "",
+                  std::string rangeMax = ""
                   );
 
-    bool AddFloatField(METAIO_STL::string name,
-                       METAIO_STL::string description,
+    bool AddFloatField(std::string name,
+                       std::string description,
                        float value,
-                       METAIO_STL::string rangeMin = "",
-                       METAIO_STL::string rangeMax = ""
+                       std::string rangeMin = "",
+                       std::string rangeMax = ""
                        );
 
-    bool AddIntField(METAIO_STL::string name,
-                     METAIO_STL::string description,
+    bool AddIntField(std::string name,
+                     std::string description,
                      int value,
-                     METAIO_STL::string rangeMin = "",
-                     METAIO_STL::string rangeMax = ""
+                     std::string rangeMin = "",
+                     std::string rangeMax = ""
                      );
 
-    bool AddListField(METAIO_STL::string name,
-                      METAIO_STL::string description,
+    bool AddListField(std::string name,
+                      std::string description,
                       ListType list);
 
     /** Set the metaCommand for parsing */
@@ -139,7 +139,7 @@ class METAIO_EXPORT MetaOutput
     void Write();
 
     /** Add a standard stream */
-    void AddStream(const char* name,METAIO_STREAM::ostream & stream);
+    void AddStream(const char* name,std::ostream & stream);
     void AddStream(const char* name,MetaOutputStream * stream);
 
     /** Add a stream file. Helper function */
@@ -149,21 +149,21 @@ class METAIO_EXPORT MetaOutput
     void EnableStream(const char* name);
     void DisableStream(const char* name);
 
-    METAIO_STL::string GetHostname(void);
-    METAIO_STL::string GetHostip(void);
+    std::string GetHostname(void);
+    std::string GetHostip(void);
 
   private:
 
-    METAIO_STL::string TypeToString(TypeEnumType type);
+    std::string TypeToString(TypeEnumType type);
 
     /** Private function to fill in the buffer */
-    METAIO_STL::string GenerateXML(const char* filename=NULL);
-    METAIO_STL::string GetUsername(void);
+    std::string GenerateXML(const char* filename=NULL);
+    std::string GetUsername(void);
 
     FieldVector   m_FieldVector;
     MetaCommand*  m_MetaCommand;
     StreamVector  m_StreamVector;
-    METAIO_STL::string   m_CurrentVersion;
+    std::string   m_CurrentVersion;
 
 }; // end of class
 

--- a/src/metaScene.cxx
+++ b/src/metaScene.cxx
@@ -53,7 +53,7 @@ MetaScene()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene()" << METAIO_STREAM::endl;
+    std::cout << "MetaScene()" << std::endl;
     }
   Clear();
 }
@@ -66,7 +66,7 @@ MetaScene::
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene()" << METAIO_STREAM::endl;
+    std::cout << "MetaScene()" << std::endl;
     }
   Clear();
   CopyInfo(_scene);
@@ -79,7 +79,7 @@ MetaScene::
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene()" << METAIO_STREAM::endl;
+    std::cout << "MetaScene()" << std::endl;
     }
   Clear();
 }
@@ -98,7 +98,7 @@ void MetaScene::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "Number of Objects = " << m_NObjects << METAIO_STREAM::endl;
+  std::cout << "Number of Objects = " << m_NObjects << std::endl;
 }
 
 void MetaScene::
@@ -131,7 +131,7 @@ Read(const char *_headerName)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene: Read" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: Read" << std::endl;
     }
 
   int i = 0;
@@ -153,26 +153,26 @@ Read(const char *_headerName)
     strcpy(m_FileName, _headerName);
     }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaScene: Read: Opening stream" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaScene: Read: Opening stream" << std::endl;
 
   M_PrepareNewReadStream();
 
 #ifdef __sgi
-  m_ReadStream->open(m_FileName, METAIO_STREAM::ios::in);
+  m_ReadStream->open(m_FileName, std::ios::in);
 #else
-  m_ReadStream->open(m_FileName, METAIO_STREAM::ios::binary
-                                 | METAIO_STREAM::ios::in);
+  m_ReadStream->open(m_FileName, std::ios::binary
+                                 | std::ios::in);
 #endif
 
   if(!m_ReadStream->rdbuf()->is_open())
     {
-    METAIO_STREAM::cout << "MetaScene: Read: Cannot open file" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: Read: Cannot open file" << std::endl;
     return false;
     }
 
   if(!M_Read())
     {
-    METAIO_STREAM::cout << "MetaScene: Read: Cannot parse file" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: Read: Cannot parse file" << std::endl;
     m_ReadStream->close();
     return false;
     }
@@ -192,8 +192,8 @@ Read(const char *_headerName)
     {
     if(META_DEBUG)
       {
-      METAIO_STREAM::cout << MET_ReadType(*m_ReadStream).c_str()
-        << METAIO_STREAM::endl;
+      std::cout << MET_ReadType(*m_ReadStream).c_str()
+        << std::endl;
       }
 
     if(m_Event)
@@ -201,7 +201,7 @@ Read(const char *_headerName)
       m_Event->SetCurrentIteration(i+1);
       }
 
-    const METAIO_STL::string objectType = MET_ReadType(*m_ReadStream);
+    const std::string objectType = MET_ReadType(*m_ReadStream);
     if(!strncmp(objectType.c_str(),"Tube",4) ||
       ((objectType.size()==0) && !strcmp(suf, "tre")))
       {
@@ -382,7 +382,7 @@ Write(const char *_headName)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene: Write" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: Write" << std::endl;
     }
 
   if(_headName != nullptr)
@@ -398,19 +398,19 @@ Write(const char *_headName)
 
   if(!m_WriteStream)
     {
-    m_WriteStream = new METAIO_STREAM::ofstream;
+    m_WriteStream = new std::ofstream;
     }
 
 #ifdef __sgi
   // Create the file. This is required on some older sgi's
     {
-    METAIO_STREAM::ofstream tFile(m_FileName, METAIO_STREAM::ios::out);
+    std::ofstream tFile(m_FileName, std::ios::out);
     tFile.close();
     }
-  m_WriteStream->open(m_FileName, METAIO_STREAM::ios::out);
+  m_WriteStream->open(m_FileName, std::ios::out);
 #else
-  m_WriteStream->open(m_FileName, METAIO_STREAM::ios::binary
-    | METAIO_STREAM::ios::out);
+  m_WriteStream->open(m_FileName, std::ios::binary
+    | std::ios::out);
 #endif
 
   if(!m_WriteStream->rdbuf()->is_open())
@@ -444,7 +444,7 @@ Clear()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: Clear" << std::endl;
     }
   MetaObject::Clear();
   // Delete the list of pointers to objects in the scene.
@@ -473,7 +473,7 @@ M_SetupReadFields()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene: M_SetupReadFields" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: M_SetupReadFields" << std::endl;
     }
 
   MetaObject::M_SetupReadFields();
@@ -526,7 +526,7 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout<<"MetaScene: M_Read: Loading Header"<<METAIO_STREAM::endl;
+    std::cout<<"MetaScene: M_Read: Loading Header"<<std::endl;
     }
 
   if(strncmp(MET_ReadType(*m_ReadStream).c_str(),"Scene",5))
@@ -537,13 +537,13 @@ M_Read()
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaScene: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaScene: M_Read: Parsing Header" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: M_Read: Parsing Header" << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -562,7 +562,7 @@ M_Write()
 {
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaScene: M_Write: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaScene: M_Write: Error parsing file" << std::endl;
     return false;
     }
 

--- a/src/metaScene.h
+++ b/src/metaScene.h
@@ -49,7 +49,7 @@ class METAIO_EXPORT MetaScene : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<MetaObject*>    ObjectListType;
+   typedef std::list<MetaObject*>    ObjectListType;
 
    ////
     //
@@ -78,7 +78,7 @@ class METAIO_EXPORT MetaScene : public MetaObject
 
     bool Write(const char *_headName=NULL);
 
-    bool Append(const char* =NULL) override {METAIO_STREAM::cout << "Not Implemented !" << METAIO_STREAM::endl;return true;}
+    bool Append(const char* =NULL) override {std::cout << "Not Implemented !" << std::endl;return true;}
 
     void  Clear(void) override;
 

--- a/src/metaSurface.cxx
+++ b/src/metaSurface.cxx
@@ -57,7 +57,7 @@ MetaSurface::
 MetaSurface()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface()" << std::endl;
   Clear();
 }
 
@@ -66,7 +66,7 @@ MetaSurface::
 MetaSurface(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaSurface()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaSurface()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -76,7 +76,7 @@ MetaSurface::
 MetaSurface(const MetaSurface *_surface)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaSurface()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaSurface()" << std::endl;
   Clear();
   CopyInfo(_surface);
 }
@@ -88,7 +88,7 @@ MetaSurface::
 MetaSurface(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface()" << std::endl;
   Clear();
 }
 
@@ -106,11 +106,11 @@ void MetaSurface::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaSurface::
@@ -149,7 +149,7 @@ NPoints() const
 void MetaSurface::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface: Clear" << std::endl;
   MetaObject::Clear();
   m_NPoints = 0;
   // Delete the list of pointers to tubes.
@@ -176,7 +176,7 @@ M_Destroy()
 void MetaSurface::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -205,7 +205,7 @@ M_SetupReadFields()
 void MetaSurface::
 M_SetupWriteFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface: M_SetupWriteFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface: M_SetupWriteFields" << std::endl;
 
   strcpy(m_ObjectTypeName,"Surface");
   MetaObject::M_SetupWriteFields();
@@ -253,15 +253,15 @@ ElementType(MET_ValueEnumType _elementType)
 bool MetaSurface::
 M_Read()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface: M_Read: Loading Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface: M_Read: Loading Header" << std::endl;
 
   if(!MetaObject::M_Read())
   {
-    METAIO_STREAM::cout << "MetaSurface: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaSurface: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface: M_Read: Parsing Header" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface: M_Read: Parsing Header" << std::endl;
 
   MET_FieldRecordType * mF;
 
@@ -309,9 +309,9 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
     {
-      METAIO_STREAM::cout << "MetaSurface: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaSurface: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc << std::endl;
       delete [] _data;
       return false;
     }
@@ -412,11 +412,11 @@ bool MetaSurface::
 M_Write()
 {
 
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaSurface: M_Write" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaSurface: M_Write" << std::endl;
 
   if(!MetaObject::M_Write())
   {
-    METAIO_STREAM::cout << "MetaSurface: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaSurface: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
@@ -485,7 +485,7 @@ M_Write()
         *m_WriteStream << (*it)->m_Color[d] << " ";
       }
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
     }
   }

--- a/src/metaSurface.h
+++ b/src/metaSurface.h
@@ -65,7 +65,7 @@ class METAIO_EXPORT MetaSurface : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<SurfacePnt*> PointListType;
+   typedef std::list<SurfacePnt*> PointListType;
     ////
     //
     // Constructors & Destructor

--- a/src/metaTransform.cxx
+++ b/src/metaTransform.cxx
@@ -29,7 +29,7 @@ MetaTransform::
 MetaTransform()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTransform()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTransform()" << std::endl;
   Clear();
 }
 
@@ -38,7 +38,7 @@ MetaTransform::
 MetaTransform(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaTransform()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaTransform()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -48,7 +48,7 @@ MetaTransform::
 MetaTransform(const MetaTransform *_group)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaTransform()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaTransform()" << std::endl;
   Clear();
   CopyInfo(_group);
 }
@@ -57,7 +57,7 @@ MetaTransform::
 MetaTransform(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTransform()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTransform()" << std::endl;
   Clear();
 }
 
@@ -86,7 +86,7 @@ CopyInfo(const MetaObject * _object)
 void MetaTransform::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTransform: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTransform: Clear" << std::endl;
   MetaObject::Clear();
   delete parameters;
   parameters = nullptr;
@@ -114,7 +114,7 @@ M_Destroy()
 void MetaTransform::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTransform: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTransform: M_SetupReadFields" << std::endl;
   MetaObject::M_SetupReadFields();
 
   int nDimsRecordNumber = MET_GetFieldRecordNumber("NDims", &m_Fields);
@@ -316,7 +316,7 @@ M_Write()
 
   if(!MetaObject::M_Write())
   {
-    METAIO_STREAM::cout << "MetaLandmark: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaLandmark: M_Read: Error parsing file" << std::endl;
     return false;
   }
 
@@ -340,7 +340,7 @@ M_Write()
       {
       *m_WriteStream << parameters[i] << " ";
       }
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
     }
 
   return true;
@@ -430,18 +430,18 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTransform: M_Read: Loading Header" << METAIO_STREAM::endl;
+    std::cout << "MetaTransform: M_Read: Loading Header" << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaTransform: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaTransform: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTransform: M_Read: Parsing Header" << METAIO_STREAM::endl;
+    std::cout << "MetaTransform: M_Read: Parsing Header" << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -508,9 +508,9 @@ M_Read()
     unsigned int gc = static_cast<unsigned int>(m_ReadStream->gcount());
     if(gc != parametersDimension*sizeof(double))
       {
-      METAIO_STREAM::cout << "MetaTransform: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << parametersDimension*sizeof(double) << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaTransform: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << parametersDimension*sizeof(double) << " : actual = " << gc << std::endl;
       delete [] _data;
       return false;
       }

--- a/src/metaTube.cxx
+++ b/src/metaTube.cxx
@@ -62,7 +62,7 @@ MetaTube::
 MetaTube()
 :MetaObject()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTube()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTube()" << std::endl;
   Clear();
 }
 
@@ -71,7 +71,7 @@ MetaTube::
 MetaTube(const char *_headerName)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaTube()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaTube()" << std::endl;
   Clear();
   Read(_headerName);
 }
@@ -81,7 +81,7 @@ MetaTube::
 MetaTube(const MetaTube *_tube)
 :MetaObject()
 {
-  if(META_DEBUG)  METAIO_STREAM::cout << "MetaTube()" << METAIO_STREAM::endl;
+  if(META_DEBUG)  std::cout << "MetaTube()" << std::endl;
   Clear();
   CopyInfo(_tube);
 }
@@ -91,7 +91,7 @@ MetaTube::
 MetaTube(unsigned int dim)
 :MetaObject(dim)
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTube()" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTube()" << std::endl;
   Clear();
 }
 
@@ -116,20 +116,20 @@ void MetaTube::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "ParentPoint = " << m_ParentPoint << METAIO_STREAM::endl;
+  std::cout << "ParentPoint = " << m_ParentPoint << std::endl;
   if(m_Root)
     {
-    METAIO_STREAM::cout << "Root = " << "True" << METAIO_STREAM::endl;
+    std::cout << "Root = " << "True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "Root = " << "True" << METAIO_STREAM::endl;
+    std::cout << "Root = " << "True" << std::endl;
     }
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaTube::
@@ -193,7 +193,7 @@ ParentPoint() const
 void MetaTube::
 Clear()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTube: Clear" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTube: Clear" << std::endl;
   MetaObject::Clear();
   // Delete the list of pointers to tubes.
   PointListType::iterator it = m_PointList.begin();
@@ -223,7 +223,7 @@ M_Destroy()
 void MetaTube::
 M_SetupReadFields()
 {
-  if(META_DEBUG) METAIO_STREAM::cout << "MetaTube: M_SetupReadFields" << METAIO_STREAM::endl;
+  if(META_DEBUG) std::cout << "MetaTube: M_SetupReadFields" << std::endl;
 
   MetaObject::M_SetupReadFields();
 
@@ -308,18 +308,18 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTube: M_Read: Loading Header" << METAIO_STREAM::endl;
+    std::cout << "MetaTube: M_Read: Loading Header" << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaTube: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaTube: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTube: M_Read: Parsing Header" << METAIO_STREAM::endl;
+    std::cout << "MetaTube: M_Read: Parsing Header" << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -387,7 +387,7 @@ M_Read()
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTube: Parsing point dim" << METAIO_STREAM::endl;
+    std::cout << "MetaTube: Parsing point dim" << std::endl;
     }
 
   int j;
@@ -500,10 +500,10 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
       {
-      METAIO_STREAM::cout << "MetaLine: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize
-                << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaLine: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize
+                << " : actual = " << gc << std::endl;
       delete [] posDim;
       delete [] _data;
       return false;
@@ -736,7 +736,7 @@ M_Write()
 
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaTube: M_Read: Error parsing file" << METAIO_STREAM::endl;
+    std::cout << "MetaTube: M_Read: Error parsing file" << std::endl;
     return false;
     }
 
@@ -850,7 +850,7 @@ M_Write()
 
       *m_WriteStream << (*it)->m_ID << " ";
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }

--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -67,7 +67,7 @@ class METAIO_EXPORT MetaTube : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<TubePnt*> PointListType;
+   typedef std::list<TubePnt*> PointListType;
     ////
     //
     // Constructors & Destructor

--- a/src/metaTubeGraph.cxx
+++ b/src/metaTubeGraph.cxx
@@ -30,7 +30,7 @@ MetaTubeGraph()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph()" << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph()" << std::endl;
     }
   Clear();
 }
@@ -42,7 +42,7 @@ MetaTubeGraph(const char *_headerName)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph()" << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph()" << std::endl;
     }
   Clear();
   Read(_headerName);
@@ -55,7 +55,7 @@ MetaTubeGraph(const MetaTubeGraph *_tube)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph()" << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph()" << std::endl;
     }
   Clear();
   CopyInfo(_tube);
@@ -68,7 +68,7 @@ MetaTubeGraph(unsigned int dim)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph()" << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph()" << std::endl;
     }
   Clear();
 }
@@ -94,12 +94,12 @@ void MetaTubeGraph::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "Root = " << m_Root << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "Root = " << m_Root << std::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaTubeGraph::
@@ -153,7 +153,7 @@ Clear()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: Clear" << std::endl;
     }
   MetaObject::Clear();
   // Delete the list of pointers to tubes.
@@ -185,8 +185,8 @@ M_SetupReadFields()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: M_SetupReadFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: M_SetupReadFields"
+                        << std::endl;
     }
 
   MetaObject::M_SetupReadFields();
@@ -302,21 +302,21 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: M_Read: Loading Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: M_Read: Loading Header"
+                        << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: M_Read: Parsing Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: M_Read: Parsing Header"
+                        << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -352,8 +352,8 @@ M_Read()
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: Parsing point dim"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: Parsing point dim"
+                        << std::endl;
     }
 
   unsigned int j;
@@ -405,10 +405,10 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
       {
-      METAIO_STREAM::cout << "MetaLine: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize << " : actual = " << gc
-                << METAIO_STREAM::endl;
+      std::cout << "MetaLine: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize << " : actual = " << gc
+                << std::endl;
       delete [] _data;
       return false;
       }
@@ -519,8 +519,8 @@ M_Write()
 
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaTubeGraph: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaTubeGraph: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
@@ -575,7 +575,7 @@ M_Write()
         *m_WriteStream << (*it)->m_T[d] << " ";
         }
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
 
       ++it;
       }

--- a/src/metaTubeGraph.h
+++ b/src/metaTubeGraph.h
@@ -76,7 +76,7 @@ class METAIO_EXPORT MetaTubeGraph : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::vector<TubeGraphPnt*> PointListType;
+   typedef std::vector<TubeGraphPnt*> PointListType;
     ////
     //
     // Constructors & Destructor

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -62,13 +62,13 @@ int META_DEBUG = 0;
 
 static char MET_SeperatorChar = '=';
 
-static const METAIO_STL::streamoff MET_MaxChunkSize = 1024*1024*1024;
+static const std::streamoff MET_MaxChunkSize = 1024*1024*1024;
 
 MET_FieldRecordType *
 MET_GetFieldRecord(const char * _fieldName,
-                   METAIO_STL::vector<MET_FieldRecordType *> * _fields)
+                   std::vector<MET_FieldRecordType *> * _fields)
   {
-  METAIO_STL::vector<MET_FieldRecordType *>::iterator fieldIter;
+  std::vector<MET_FieldRecordType *>::iterator fieldIter;
   for(fieldIter=_fields->begin(); fieldIter!=_fields->end(); ++fieldIter)
     {
     if(!strcmp((*fieldIter)->name, _fieldName))
@@ -82,7 +82,7 @@ MET_GetFieldRecord(const char * _fieldName,
 
 int
 MET_GetFieldRecordNumber(const char * _fieldName,
-                         METAIO_STL::vector<MET_FieldRecordType *> * _fields)
+                         std::vector<MET_FieldRecordType *> * _fields)
   {
   int i;
   for(i=0; i<(int)_fields->size(); i++)
@@ -135,10 +135,10 @@ bool MET_SystemByteOrderMSB()
 //
 // Read the type of the object
 //
-METAIO_STL::string MET_ReadForm(METAIO_STREAM::istream &_fp)
+std::string MET_ReadForm(std::istream &_fp)
   {
-  METAIO_STL::streampos pos = _fp.tellg();
-  METAIO_STL::vector<MET_FieldRecordType *> fields;
+  std::streampos pos = _fp.tellg();
+  std::vector<MET_FieldRecordType *> fields;
   MET_FieldRecordType* mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "FormTypeName", MET_STRING, false);
   mF->required = false;
@@ -150,22 +150,22 @@ METAIO_STL::string MET_ReadForm(METAIO_STREAM::istream &_fp)
 
   if(mF->defined)
     {
-    METAIO_STL::string value = (char *)(mF->value);
+    std::string value = (char *)(mF->value);
     delete mF;
     return value;
     }
 
   delete mF;
-  return METAIO_STL::string();
+  return std::string();
   }
 
 //
 // Read the type of the object
 //
-METAIO_STL::string MET_ReadType(METAIO_STREAM::istream &_fp)
+std::string MET_ReadType(std::istream &_fp)
   {
-  METAIO_STL::streampos pos = _fp.tellg();
-  METAIO_STL::vector<MET_FieldRecordType *> fields;
+  std::streampos pos = _fp.tellg();
+  std::vector<MET_FieldRecordType *> fields;
   MET_FieldRecordType* mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "ObjectType", MET_STRING, false);
   mF->required = false;
@@ -177,22 +177,22 @@ METAIO_STL::string MET_ReadType(METAIO_STREAM::istream &_fp)
 
   if(mF->defined)
     {
-    METAIO_STL::string value  = (char *)(mF->value);
+    std::string value  = (char *)(mF->value);
     delete mF;
     return value;
     }
 
   delete mF;
-  return METAIO_STL::string();
+  return std::string();
   }
 
 //
 // Read the subtype of the object
 //
-char* MET_ReadSubType(METAIO_STREAM::istream &_fp)
+char* MET_ReadSubType(std::istream &_fp)
   {
-  METAIO_STL::streampos pos = _fp.tellg();
-  METAIO_STL::vector<MET_FieldRecordType *> fields;
+  std::streampos pos = _fp.tellg();
+  std::vector<MET_FieldRecordType *> fields;
   MET_FieldRecordType* mF;
   mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "ObjectType", MET_STRING, false);
@@ -204,9 +204,9 @@ char* MET_ReadSubType(METAIO_STREAM::istream &_fp)
   // Find the line right after the ObjectType
   char s[1024];
   _fp.getline( s, 500 );
-  METAIO_STL::string value = s;
+  std::string value = s;
   size_t position = value.find('=');
-  if(position!=METAIO_STL::string::npos)
+  if(position!=std::string::npos)
     {
     value = value.substr(position+2,value.size()-position);
     }
@@ -260,7 +260,7 @@ bool MET_TypeToString(MET_ValueEnumType _vType, char *_s)
 // Value to Double
 //
 bool MET_ValueToDouble(MET_ValueEnumType _type, const void *_data,
-                       METAIO_STL::streamoff _index,
+                       std::streamoff _index,
                        double *_value)
   {
   switch(_type)
@@ -335,7 +335,7 @@ bool MET_ValueToDouble(MET_ValueEnumType _type, const void *_data,
 bool MET_DoubleToValue(double _value,
                        MET_ValueEnumType _type,
                        void *_data,
-                       METAIO_STL::streamoff _index)
+                       std::streamoff _index)
   {
   switch(_type)
     {
@@ -400,7 +400,7 @@ bool MET_DoubleToValue(double _value,
   }
 
 bool MET_ValueToValue(MET_ValueEnumType _fromType, const void *_fromData,
-                      METAIO_STL::streamoff _index,
+                      std::streamoff _index,
                       MET_ValueEnumType _toType, void *_toData,
                       double _fromMin, double _fromMax,
                       double _toMin, double _toMax)
@@ -483,29 +483,29 @@ bool MET_ValueToValue(MET_ValueEnumType _fromType, const void *_fromData,
 
 // Uncompress a stream given an uncompressedSeekPosition
 METAIO_EXPORT
-METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
-                          METAIO_STL::streamoff uncompressedSeekPosition,
+std::streamoff MET_UncompressStream(std::ifstream * stream,
+                          std::streamoff uncompressedSeekPosition,
                           unsigned char * uncompressedData,
-                          METAIO_STL::streamoff uncompressedDataSize,
-                          METAIO_STL::streamoff compressedDataSize,
+                          std::streamoff uncompressedDataSize,
+                          std::streamoff compressedDataSize,
                           MET_CompressionTableType * compressionTable
                           )
 {
   // Keep the currentpos of the string
-  METAIO_STL::streampos currentPos = stream->tellg();
-  if(currentPos == METAIO_STL::streampos(-1))
+  std::streampos currentPos = stream->tellg();
+  if(currentPos == std::streampos(-1))
     {
-    METAIO_STREAM::cout << "MET_UncompressStream: ERROR Stream is not valid!" << METAIO_STREAM::endl;
+    std::cout << "MET_UncompressStream: ERROR Stream is not valid!" << std::endl;
     return -1;
     }
 
-  METAIO_STL::streamoff read = 0;
+  std::streamoff read = 0;
 
-  //METAIO_STREAM::cout << "Wanted Seek = " << uncompressedSeekPosition << METAIO_STREAM::endl;
-  //METAIO_STREAM::cout << "Wanted size = " << uncompressedDataSize << METAIO_STREAM::endl;
+  //std::cout << "Wanted Seek = " << uncompressedSeekPosition << std::endl;
+  //std::cout << "Wanted size = " << uncompressedDataSize << std::endl;
 
   // Size of the output buffer
-  METAIO_STL::streamoff buffersize = 1000;
+  std::streamoff buffersize = 1000;
 
   // We try to guess the compression rate
   // Note that sometime the size of the input buffer
@@ -513,8 +513,8 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
   // We assume that they are equal
   double compressionRate = 1;
 
-  METAIO_STL::streamoff zseekpos = 0;
-  METAIO_STL::streamoff seekpos = 0;
+  std::streamoff zseekpos = 0;
+  std::streamoff seekpos = 0;
   bool firstchunk = true;
 
   // Allocate the stream if necessary
@@ -544,17 +544,17 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
       {
       if((*it).uncompressedOffset-uncompressedSeekPosition > compressionTable->bufferSize)
         {
-        METAIO_STREAM::cout << "ERROR: Cannot go backward by more than the buffer size (1000)"
-                  << METAIO_STREAM::endl;
+        std::cout << "ERROR: Cannot go backward by more than the buffer size (1000)"
+                  << std::endl;
         return 0;
         }
 
       char* buffer = compressionTable->buffer;
-      METAIO_STL::streamoff start = uncompressedSeekPosition-((*it).uncompressedOffset-compressionTable->bufferSize);
+      std::streamoff start = uncompressedSeekPosition-((*it).uncompressedOffset-compressionTable->bufferSize);
       buffer += start;
 
-      METAIO_STL::streamoff readSize = uncompressedDataSize;
-      METAIO_STL::streamoff sizeInBuffer = compressionTable->bufferSize-start;
+      std::streamoff readSize = uncompressedDataSize;
+      std::streamoff sizeInBuffer = compressionTable->bufferSize-start;
       if(readSize>sizeInBuffer)
         {
         memcpy(uncompressedData,buffer,(size_t)sizeInBuffer);
@@ -577,7 +577,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
       }
     }
 
-  //METAIO_STREAM::cout << "Using = " << seekpos << " : " << zseekpos << METAIO_STREAM::endl;
+  //std::cout << "Using = " << seekpos << " : " << zseekpos << std::endl;
 
   while(seekpos < uncompressedSeekPosition+uncompressedDataSize)
     {
@@ -593,7 +593,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
     d_stream->avail_out = (uInt)( buffersize );
 
     // How many byte from compressed streamed should we read
-    METAIO_STL::streamoff inputBufferSize = (METAIO_STL::streamoff)(buffersize/compressionRate);
+    std::streamoff inputBufferSize = (std::streamoff)(buffersize/compressionRate);
 
     if(inputBufferSize == 0)
       {
@@ -605,7 +605,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
       }
 
     unsigned char* inputBuffer = new unsigned char[static_cast<size_t>(inputBufferSize)];
-    stream->seekg(currentPos+zseekpos,METAIO_STREAM::ios::beg);
+    stream->seekg(currentPos+zseekpos,std::ios::beg);
     stream->read((char *)inputBuffer, (size_t)inputBufferSize);
 
     d_stream->next_in  = inputBuffer;
@@ -618,14 +618,14 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
       return -1;
       }
 
-    METAIO_STL::streampos previousSeekpos = seekpos;
+    std::streampos previousSeekpos = seekpos;
 
     seekpos += buffersize-d_stream->avail_out;
     zseekpos += stream->gcount()-d_stream->avail_in;
 
     // Store the last buffer into memory in case we need it
     // in the near future.
-    METAIO_STL::streamoff previousBufferSize = seekpos-previousSeekpos;
+    std::streamoff previousBufferSize = seekpos-previousSeekpos;
     if(previousBufferSize>1000)
       {
       // WARNING: We probably need to offset outdata at some point...
@@ -635,7 +635,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
     memcpy(compressionTable->buffer,outdata,(size_t)previousBufferSize);
     compressionTable->bufferSize = previousBufferSize;
 
-    //METAIO_STREAM::cout << "Current pos = " << seekpos << " : " << zseekpos << METAIO_STREAM::endl;
+    //std::cout << "Current pos = " << seekpos << " : " << zseekpos << std::endl;
 
     // If go further than the uncompressedSeekPosition we start writing the stream
     if(seekpos >= uncompressedSeekPosition)
@@ -643,7 +643,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
       if(firstchunk)
         {
         outdata += uncompressedSeekPosition-previousSeekpos;
-        METAIO_STL::streamoff writeSize = seekpos-uncompressedSeekPosition;
+        std::streamoff writeSize = seekpos-uncompressedSeekPosition;
 
         if(writeSize > uncompressedDataSize)
           {
@@ -662,7 +662,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
         }
       else // read everything
         {
-        METAIO_STL::streamoff writeSize = seekpos-previousSeekpos;
+        std::streamoff writeSize = seekpos-previousSeekpos;
         memcpy(uncompressedData,outdata,(size_t)writeSize);
         if(writeSize > uncompressedDataSize)
           {
@@ -683,7 +683,7 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
   compressionTable->offsetList.push_back(offset);
 
   // Seek to the current position
-  stream->seekg(currentPos,METAIO_STREAM::ios::beg);
+  stream->seekg(currentPos,std::ios::beg);
   return read;
 }
 
@@ -692,8 +692,8 @@ METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
 //
 //
 unsigned char * MET_PerformCompression(const unsigned char * source,
-                                       METAIO_STL::streamoff sourceSize,
-                                       METAIO_STL::streamoff * compressedDataSize)
+                                       std::streamoff sourceSize,
+                                       std::streamoff * compressedDataSize)
   {
 
   z_stream  z;
@@ -705,9 +705,9 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
   // Choices are Z_BEST_SPEED,Z_BEST_COMPRESSION,Z_DEFAULT_COMPRESSION
   int compression_rate = Z_DEFAULT_COMPRESSION;
 
-  METAIO_STL::streamoff buffer_out_size = sourceSize;
-  METAIO_STL::streamoff max_chunk_size = MET_MaxChunkSize;
-  METAIO_STL::streamoff chunk_size  = std::min(sourceSize, max_chunk_size);
+  std::streamoff buffer_out_size = sourceSize;
+  std::streamoff max_chunk_size = MET_MaxChunkSize;
+  std::streamoff chunk_size  = std::min(sourceSize, max_chunk_size);
   unsigned char * input_buffer      = const_cast<unsigned char *>(source);
   unsigned char * output_buffer     = new unsigned char[chunk_size];
   unsigned char * compressed_data   = new unsigned char[buffer_out_size];
@@ -715,8 +715,8 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
   /*int ret =*/ deflateInit(&z, compression_rate);
   //assert(ret == Z_OK);
 
-  METAIO_STL::streamoff cur_in_start = 0;
-  METAIO_STL::streamoff cur_out_start = 0;
+  std::streamoff cur_in_start = 0;
+  std::streamoff cur_out_start = 0;
   int flush;
   do
     {
@@ -731,7 +731,7 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
       z.next_out  = output_buffer;
       /*ret =*/ deflate(&z, flush);
       //assert(ret != Z_STREAM_ERROR);
-      METAIO_STL::streamoff count_out = chunk_size - z.avail_out;
+      std::streamoff count_out = chunk_size - z.avail_out;
       if ( (cur_out_start + count_out) >= buffer_out_size )
         {
         // if we don't have enough allocation for the output buffer
@@ -760,9 +760,9 @@ unsigned char * MET_PerformCompression(const unsigned char * source,
 //
 //
 bool MET_PerformUncompression(const unsigned char * sourceCompressed,
-                              METAIO_STL::streamoff sourceCompressedSize,
+                              std::streamoff sourceCompressedSize,
                               unsigned char * uncompressedData,
-                              METAIO_STL::streamoff uncompressedDataSize)
+                              std::streamoff uncompressedDataSize)
   {
   z_stream d_stream;
 
@@ -772,9 +772,9 @@ bool MET_PerformUncompression(const unsigned char * sourceCompressed,
 
   inflateInit2(&d_stream,47); // allow both gzip and zlib compression headers
 
-  METAIO_STL::streamoff max_chunk_size = MET_MaxChunkSize;
-  METAIO_STL::streamoff source_pos = 0;
-  METAIO_STL::streamoff dest_pos = 0;
+  std::streamoff max_chunk_size = MET_MaxChunkSize;
+  std::streamoff source_pos = 0;
+  std::streamoff dest_pos = 0;
   int err;
   do
     {
@@ -796,7 +796,7 @@ bool MET_PerformUncompression(const unsigned char * sourceCompressed,
         if (err != Z_STREAM_END &&
             err != Z_BUF_ERROR) // Z_BUF_ERROR means there is still data to uncompress,
           {                     // but no space left in buffer; non-fatal
-          METAIO_STREAM::cerr << "Uncompress failed" << METAIO_STREAM::endl;
+          std::cerr << "Uncompress failed" << std::endl;
           }
           break;
         }
@@ -1000,7 +1000,7 @@ bool MET_InitReadField(MET_FieldRecordType * _mf,
 //
 //
 //
-static bool MET_SkipToVal(METAIO_STREAM::istream &fp)
+static bool MET_SkipToVal(std::istream &fp)
   {
   int c;
   if( fp.eof() )
@@ -1022,8 +1022,8 @@ static bool MET_SkipToVal(METAIO_STREAM::istream &fp)
 
   if( fp.eof() )
     {
-    METAIO_STREAM::cerr << "Incomplete file record definition"
-                        << METAIO_STREAM::endl;
+    std::cerr << "Incomplete file record definition"
+                        << std::endl;
     return false;
     }
 
@@ -1035,15 +1035,15 @@ static bool MET_SkipToVal(METAIO_STREAM::istream &fp)
 //
 //
 //
-static bool MET_IsComplete(METAIO_STL::vector<MET_FieldRecordType *> * fields)
+static bool MET_IsComplete(std::vector<MET_FieldRecordType *> * fields)
   {
-  METAIO_STL::vector<MET_FieldRecordType *>::iterator fieldIter;
+  std::vector<MET_FieldRecordType *>::iterator fieldIter;
   for(fieldIter=fields->begin(); fieldIter!=fields->end(); ++fieldIter)
     {
     if((*fieldIter)->required && !(*fieldIter)->defined)
       {
-      METAIO_STREAM::cerr << (*fieldIter)->name << " required and not defined."
-                << METAIO_STREAM::endl;
+      std::cerr << (*fieldIter)->name << " required and not defined."
+                << std::endl;
       return false;
       }
     }
@@ -1051,17 +1051,17 @@ static bool MET_IsComplete(METAIO_STL::vector<MET_FieldRecordType *> * fields)
   }
 
 //
-bool MET_Read(METAIO_STREAM::istream &fp,
-              METAIO_STL::vector<MET_FieldRecordType *> * fields,
+bool MET_Read(std::istream &fp,
+              std::vector<MET_FieldRecordType *> * fields,
               char _MET_SeperatorChar, bool oneLine, bool display_warnings,
-              METAIO_STL::vector<MET_FieldRecordType *> * newFields)
+              std::vector<MET_FieldRecordType *> * newFields)
   {
 
   char s[1024];
   int i;
   size_t j;
 
-  METAIO_STL::vector<MET_FieldRecordType *>::iterator fieldIter;
+  std::vector<MET_FieldRecordType *>::iterator fieldIter;
 
   MET_SeperatorChar = _MET_SeperatorChar;
 
@@ -1105,10 +1105,10 @@ bool MET_Read(METAIO_STREAM::istream &fp,
         if((*fieldIter)->dependsOn >= 0)
           if(!(*fields)[(*fieldIter)->dependsOn]->defined)
             {
-            METAIO_STREAM::cerr << (*fieldIter)->name
+            std::cerr << (*fieldIter)->name
                                 << " defined prior to defining ";
-            METAIO_STREAM::cerr << (*fields)[(*fieldIter)->dependsOn]->name
-                                << METAIO_STREAM::endl;
+            std::cerr << (*fields)[(*fieldIter)->dependsOn]->name
+                                << std::endl;
             return false;
             }
         switch((*fieldIter)->type)
@@ -1196,9 +1196,9 @@ bool MET_Read(METAIO_STREAM::istream &fp,
               {
               if((*fieldIter)->length <= 0)
                 {
-                METAIO_STREAM::cerr <<
+                std::cerr <<
                   "Arrays must have dependency or pre-specified lengths"
-                  << METAIO_STREAM::endl;
+                  << std::endl;
                 return false;
                 }
               for(j=0; j<(size_t)(*fieldIter)->length; j++)
@@ -1230,9 +1230,9 @@ bool MET_Read(METAIO_STREAM::istream &fp,
               {
               if((*fieldIter)->length <= 0)
                 {
-                METAIO_STREAM::cerr <<
+                std::cerr <<
                   "Arrays must have dependency or pre-specified lengths"
-                  << METAIO_STREAM::endl;
+                  << std::endl;
                 return false;
                 }
               for(j=0; j<(size_t)(*fieldIter)->length*(*fieldIter)->length; j++)
@@ -1279,8 +1279,8 @@ bool MET_Read(METAIO_STREAM::istream &fp,
         {
         if(display_warnings)
           {
-          METAIO_STREAM::cerr << "Skipping unrecognized field "
-                              << s << METAIO_STREAM::endl;
+          std::cerr << "Skipping unrecognized field "
+                              << s << std::endl;
           }
         fp.getline( s, 500 );
         }
@@ -1309,14 +1309,14 @@ static std::string convert_ulonglong_to_string(MET_ULONG_LONG_TYPE val)
 #endif
 
 //
-bool MET_Write(METAIO_STREAM::ostream &fp,
-               METAIO_STL::vector<MET_FieldRecordType *> * fields,
+bool MET_Write(std::ostream &fp,
+               std::vector<MET_FieldRecordType *> * fields,
                char _MET_SeperatorChar)
   {
   MET_SeperatorChar = _MET_SeperatorChar;
 
   int j;
-  METAIO_STL::vector<MET_FieldRecordType *>::iterator fieldIter;
+  std::vector<MET_FieldRecordType *>::iterator fieldIter;
   for(fieldIter=fields->begin(); fieldIter!=fields->end(); ++fieldIter)
     {
     switch((*fieldIter)->type)
@@ -1324,13 +1324,13 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
       case MET_NONE:
         {
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " "
-           << METAIO_STREAM::endl;
+           << std::endl;
         break;
         }
       case MET_ASCII_CHAR:
         {
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
-        fp << (MET_CHAR_TYPE)(*fieldIter)->value[0] << METAIO_STREAM::endl;
+        fp << (MET_CHAR_TYPE)(*fieldIter)->value[0] << std::endl;
         break;
         }
       case MET_CHAR:
@@ -1339,7 +1339,7 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
       case MET_INT:
         {
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
-        fp << (MET_LONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
+        fp << (MET_LONG_TYPE)((*fieldIter)->value[0]) << std::endl;
         break;
         }
       case MET_LONG_LONG:
@@ -1347,15 +1347,15 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
 #if defined(_MSC_VER) || defined(__HP_aCC)
         // NOTE: you cannot use __int64 in an ostream in MSV6 or HPUX
         fp << (double)((MET_LONG_LONG_TYPE)((*fieldIter)->value[0]))
-           << METAIO_STREAM::endl;
-        METAIO_STREAM::cerr << "Programs compiled using MSV6 or HPUX cannot"
-                            << " write 64 bit ints" << METAIO_STREAM::endl;
-        METAIO_STREAM::cerr << "  Writing as double instead."
+           << std::endl;
+        std::cerr << "Programs compiled using MSV6 or HPUX cannot"
+                            << " write 64 bit ints" << std::endl;
+        std::cerr << "  Writing as double instead."
                             << "  Loss of precision results."
-                            << METAIO_STREAM::endl;
+                            << std::endl;
 #else
         fp << (MET_LONG_LONG_TYPE)((*fieldIter)->value[0])
-           << METAIO_STREAM::endl;
+           << std::endl;
 #endif
         break;
         }
@@ -1365,7 +1365,7 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
       case MET_ULONG:
         {
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
-        fp << (MET_ULONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
+        fp << (MET_ULONG_TYPE)((*fieldIter)->value[0]) << std::endl;
         break;
         }
       case MET_ULONG_LONG:
@@ -1373,9 +1373,9 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
 #if defined(_MSC_VER) || defined(__HP_aCC)
         // NOTE: you cannot use __int64 in an ostream in MSV6 or HPUX
-        fp << convert_ulonglong_to_string((MET_ULONG_LONG_TYPE)((*fieldIter)->value[0])) << METAIO_STREAM::endl;
+        fp << convert_ulonglong_to_string((MET_ULONG_LONG_TYPE)((*fieldIter)->value[0])) << std::endl;
 #else
-        fp << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[0]) << METAIO_STREAM::endl;
+        fp << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[0]) << std::endl;
 #endif
         break;
         }
@@ -1383,18 +1383,18 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
       case MET_DOUBLE:
         {
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
-        fp << (MET_DOUBLE_TYPE)(*fieldIter)->value[0] << METAIO_STREAM::endl;
+        fp << (MET_DOUBLE_TYPE)(*fieldIter)->value[0] << std::endl;
         break;
         }
       case MET_STRING:
         {
         if ( (*fieldIter)->length == 0 )
           {
-          METAIO_STREAM::cerr << "Warning:";
-          METAIO_STREAM::cerr << "The field " << (*fieldIter)->name
+          std::cerr << "Warning:";
+          std::cerr << "The field " << (*fieldIter)->name
                               << "has zero length. "
                               << "Refusing to write empty string value.";
-          METAIO_STREAM::cerr << METAIO_STREAM::endl;
+          std::cerr << std::endl;
           }
         fp << (*fieldIter)->name << " " << MET_SeperatorChar << " ";
         if((*fieldIter)->dependsOn >= 0)
@@ -1402,14 +1402,14 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning:";
-            METAIO_STREAM::cerr << "length and dependsOn values not equal"
+            std::cerr << "Warning:";
+            std::cerr << "length and dependsOn values not equal"
                                 << " in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << std::endl;
             }
           }
         fp.write( (char *)((*fieldIter)->value), (*fieldIter)->length );
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
       case MET_CHAR_ARRAY:
@@ -1423,17 +1423,17 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning: ";
-            METAIO_STREAM::cerr << "Length and dependsOn values not equal"
+            std::cerr << "Warning: ";
+            std::cerr << "Length and dependsOn values not equal"
                                 << " in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << std::endl;
             }
           }
         for(j=0; j<(*fieldIter)->length; j++)
           {
           fp << " " << (MET_LONG_TYPE)((*fieldIter)->value[j]);
           }
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
       case MET_LONG_LONG_ARRAY:
@@ -1444,10 +1444,10 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning: ";
-            METAIO_STREAM::cerr << "Length and dependsOn values not equal"
+            std::cerr << "Warning: ";
+            std::cerr << "Length and dependsOn values not equal"
                                 << " in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << std::endl;
             }
           }
         for(j=0; j<(*fieldIter)->length; j++)
@@ -1455,17 +1455,17 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
 #if defined(_MSC_VER) || defined(__HP_aCC)
           // NOTE: you cannot use __int64 in an ostream in MSV6 or HPUX
           fp << " " << (double)((MET_LONG_LONG_TYPE)((*fieldIter)->value[j]));
-          METAIO_STREAM::cerr << "Programs compiled using MSV6 cannot"
+          std::cerr << "Programs compiled using MSV6 cannot"
                               << " write 64 bit ints"
-                              << METAIO_STREAM::endl;
-          METAIO_STREAM::cerr << "  Writing as double instead."
+                              << std::endl;
+          std::cerr << "  Writing as double instead."
                               << " Loss of precision results."
-                              << METAIO_STREAM::endl;
+                              << std::endl;
 #else
           fp << " " << (MET_LONG_LONG_TYPE)((*fieldIter)->value[j]);
 #endif
           }
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
 
@@ -1480,17 +1480,17 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning: ";
-            METAIO_STREAM::cerr << "Length and dependsOn values not equal"
+            std::cerr << "Warning: ";
+            std::cerr << "Length and dependsOn values not equal"
                                 << " in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << std::endl;
             }
           }
         for(j=0; j<(*fieldIter)->length; j++)
           {
           fp << " " << (MET_ULONG_TYPE)((*fieldIter)->value[j]);
           }
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
       case MET_ULONG_LONG_ARRAY:
@@ -1501,10 +1501,10 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning: ";
-            METAIO_STREAM::cerr << "Length and dependsOn values not equal"
+            std::cerr << "Warning: ";
+            std::cerr << "Length and dependsOn values not equal"
                                 << " in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << std::endl;
             }
           }
         for(j=0; j<(*fieldIter)->length; j++)
@@ -1513,17 +1513,17 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           // NOTE: you cannot use __int64 in an ostream in MSV6
           fp << " " << (double)((MET_LONG_LONG_TYPE)((MET_ULONG_LONG_TYPE)
                                 ((*fieldIter)->value[j])));
-          METAIO_STREAM::cerr << "Programs compiled using MSV6 or HPUX"
+          std::cerr << "Programs compiled using MSV6 or HPUX"
                               << " cannot write 64 bit ints"
-                              << METAIO_STREAM::endl;
-          METAIO_STREAM::cerr << " Writing as double instead."
+                              << std::endl;
+          std::cerr << " Writing as double instead."
                               << " Loss of precision results."
-                              << METAIO_STREAM::endl;
+                              << std::endl;
 #else
           fp << " " << (MET_ULONG_LONG_TYPE)((*fieldIter)->value[j]);
 #endif
           }
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
 
@@ -1536,16 +1536,16 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning: ";
-            METAIO_STREAM::cerr << "length and dependsOn values not equal in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << "Warning: ";
+            std::cerr << "length and dependsOn values not equal in write";
+            std::cerr << std::endl;
             }
           }
         for(j=0; j<(*fieldIter)->length; j++)
           {
           fp << " " << (double)(*fieldIter)->value[j];
           }
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
       case MET_FLOAT_MATRIX:
@@ -1556,16 +1556,16 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
           if((*fieldIter)->length !=
              (*fields)[(*fieldIter)->dependsOn]->value[0])
             {
-            METAIO_STREAM::cerr << "Warning: ";
-            METAIO_STREAM::cerr << "length and dependsOn values not equal in write";
-            METAIO_STREAM::cerr << METAIO_STREAM::endl;
+            std::cerr << "Warning: ";
+            std::cerr << "length and dependsOn values not equal in write";
+            std::cerr << std::endl;
             }
           }
         for(j=0; j<(*fieldIter)->length*(*fieldIter)->length; j++)
           {
           fp << " " << (double)(*fieldIter)->value[j];
           }
-        fp << METAIO_STREAM::endl;
+        fp << std::endl;
         break;
         }
       case MET_OTHER:
@@ -1577,7 +1577,7 @@ bool MET_Write(METAIO_STREAM::ostream &fp,
   return true;
 }
 
-bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
+bool MET_WriteFieldToFile(std::ostream & _fp, const char *_fieldName,
                           MET_ValueEnumType _pType, size_t _n, const void *_v)
   {
   size_t i;
@@ -1698,7 +1698,7 @@ bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
       break;
     }
 
-  METAIO_STL::vector<MET_FieldRecordType *> l;
+  std::vector<MET_FieldRecordType *> l;
   l.clear();
   l.push_back(&f);
   MET_Write(_fp, &l);
@@ -1706,7 +1706,7 @@ bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
   return true;
   }
 
-bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
+bool MET_WriteFieldToFile(std::ostream & _fp, const char *_fieldName,
   MET_ValueEnumType _pType, double _v)
   {
   MET_FieldRecordType f;
@@ -1719,7 +1719,7 @@ bool MET_WriteFieldToFile(METAIO_STREAM::ostream & _fp, const char *_fieldName,
   f.type = _pType;
   f.value[0] = _v;
 
-  METAIO_STL::vector<MET_FieldRecordType *> l;
+  std::vector<MET_FieldRecordType *> l;
   l.clear();
   l.push_back(&f);
   MET_Write(_fp, &l);

--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -63,11 +63,11 @@ extern int META_DEBUG;
 // Types used for storing the compression table
 typedef struct MET_CompressionOffset
   {
-  METAIO_STL::streamoff uncompressedOffset;
-  METAIO_STL::streamoff compressedOffset;
+  std::streamoff uncompressedOffset;
+  std::streamoff compressedOffset;
   } MET_CompressionOffsetType;
 
-typedef METAIO_STL::vector<MET_CompressionOffsetType>
+typedef std::vector<MET_CompressionOffsetType>
                                                  MET_CompressionOffsetListType;
 
 typedef struct MET_CompressionTable
@@ -75,18 +75,18 @@ typedef struct MET_CompressionTable
   MET_CompressionOffsetListType offsetList;
   z_stream* compressedStream;
   char*     buffer;
-  METAIO_STL::streamoff bufferSize;
+  std::streamoff bufferSize;
   } MET_CompressionTableType;
 
 /////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////
 METAIO_EXPORT MET_FieldRecordType *
   MET_GetFieldRecord(const char * _fieldName,
-                           METAIO_STL::vector<MET_FieldRecordType *> * _fields);
+                           std::vector<MET_FieldRecordType *> * _fields);
 
 METAIO_EXPORT
 int MET_GetFieldRecordNumber(const char * _fieldName,
-                           METAIO_STL::vector<MET_FieldRecordType *> * _fields);
+                           std::vector<MET_FieldRecordType *> * _fields);
 
 METAIO_EXPORT
 bool MET_SizeOfType(MET_ValueEnumType _type, int *_size);
@@ -171,19 +171,19 @@ METAIO_EXPORT
 bool MET_StringToWordArray(const char *s, int *n, char ***val);
 
 template <class T>
-void MET_StringToVector( const METAIO_STL::string & s,
-                         METAIO_STL::vector< T > & vec,
+void MET_StringToVector( const std::string & s,
+                         std::vector< T > & vec,
                          const char separator=',' )
 {
   vec.clear();
 
-  METAIO_STL::string::size_type prevPos = 0;
-  METAIO_STL::string::size_type pos = s.find( separator, prevPos );
+  std::string::size_type prevPos = 0;
+  std::string::size_type pos = s.find( separator, prevPos );
   T tVal;
-  while( pos != METAIO_STL::string::npos )
+  while( pos != std::string::npos )
     {
-    METAIO_STL::stringstream ss;
-    METAIO_STL::string tmpString = s.substr( prevPos, (pos-prevPos) );
+    std::stringstream ss;
+    std::string tmpString = s.substr( prevPos, (pos-prevPos) );
     ss << tmpString;
     ss >> tVal;
     vec.push_back( tVal );
@@ -191,8 +191,8 @@ void MET_StringToVector( const METAIO_STL::string & s,
     prevPos = pos+1;
     pos = s.find( separator, prevPos );
     }
-  METAIO_STL::stringstream ss;
-  METAIO_STL::string tmpString = s.substr( prevPos, ( s.size() - prevPos ) );
+  std::stringstream ss;
+  std::string tmpString = s.substr( prevPos, ( s.size() - prevPos ) );
   ss << tmpString;
   ss >> tVal;
   vec.push_back( tVal );
@@ -213,7 +213,7 @@ bool MET_InterpolationTypeToString(MET_InterpolationEnumType _type,
                                 char * _str);
 
 inline
-MET_ValueEnumType MET_GetPixelType(const METAIO_STL::type_info & ptype)
+MET_ValueEnumType MET_GetPixelType(const std::type_info & ptype)
     {
     if( ptype == typeid(MET_UCHAR_TYPE) )
       {
@@ -265,14 +265,14 @@ MET_ValueEnumType MET_GetPixelType(const METAIO_STL::type_info & ptype)
       }
     else
       {
-      METAIO_STREAM::cerr << "MET_GetPixelType: Couldn't convert pixel type : "
-                << ptype.name() << METAIO_STREAM::endl;
+      std::cerr << "MET_GetPixelType: Couldn't convert pixel type : "
+                << ptype.name() << std::endl;
       return MET_NONE;
       }
     }
 
 inline
-MET_ValueEnumType MET_GetValueEnumType(const METAIO_STL::type_info & ptype)
+MET_ValueEnumType MET_GetValueEnumType(const std::type_info & ptype)
     {
     return MET_GetPixelType( ptype );
     }
@@ -298,19 +298,19 @@ void MET_StringStripEnd(MET_ASCII_CHAR_TYPE * str)
 METAIO_EXPORT
 bool MET_ValueToDouble(MET_ValueEnumType _pType,
                               const void *_data,
-                              METAIO_STL::streamoff _index,
+                              std::streamoff _index,
                               double *_value);
 
 METAIO_EXPORT
 bool MET_DoubleToValue(double _value,
                               MET_ValueEnumType _type,
                               void *_data,
-                              METAIO_STL::streamoff _index);
+                              std::streamoff _index);
 
 METAIO_EXPORT
 bool MET_ValueToValue(MET_ValueEnumType _fromType,
                              const void *_fromData,
-                             METAIO_STL::streamoff _index,
+                             std::streamoff _index,
                              MET_ValueEnumType _toType,
                              void  *_toData,
                              double _fromMin=0, double _fromMax=0,
@@ -318,22 +318,22 @@ bool MET_ValueToValue(MET_ValueEnumType _fromType,
 
 METAIO_EXPORT
 unsigned char * MET_PerformCompression(const unsigned char * source,
-                                       METAIO_STL::streamoff sourceSize,
-                                       METAIO_STL::streamoff * compressedDataSize);
+                                       std::streamoff sourceSize,
+                                       std::streamoff * compressedDataSize);
 
 METAIO_EXPORT
 bool MET_PerformUncompression(const unsigned char * sourceCompressed,
-                              METAIO_STL::streamoff sourceCompressedSize,
+                              std::streamoff sourceCompressedSize,
                               unsigned char * uncompressedData,
-                              METAIO_STL::streamoff uncompressedDataSize);
+                              std::streamoff uncompressedDataSize);
 
 // Uncompress a stream given an uncompressedSeekPosition
 METAIO_EXPORT
-METAIO_STL::streamoff MET_UncompressStream(METAIO_STREAM::ifstream * stream,
-                          METAIO_STL::streamoff uncompressedSeekPosition,
+std::streamoff MET_UncompressStream(std::ifstream * stream,
+                          std::streamoff uncompressedSeekPosition,
                           unsigned char * uncompressedData,
-                          METAIO_STL::streamoff uncompressedDataSize,
-                          METAIO_STL::streamoff compressedDataSize,
+                          std::streamoff uncompressedDataSize,
+                          std::streamoff compressedDataSize,
                           MET_CompressionTableType * compressionTable);
 
 
@@ -400,16 +400,16 @@ bool MET_InitWriteField(MET_FieldRecordType * _mf,
 /////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////
 METAIO_EXPORT
-bool MET_Write(METAIO_STREAM::ostream &fp,
-            METAIO_STL::vector<MET_FieldRecordType *> * fields,
+bool MET_Write(std::ostream &fp,
+            std::vector<MET_FieldRecordType *> * fields,
             char _sepChar='=');
 
 METAIO_EXPORT
-bool MET_WriteFieldToFile(METAIO_STREAM::ostream &_fp, const char *_fieldName,
+bool MET_WriteFieldToFile(std::ostream &_fp, const char *_fieldName,
                        MET_ValueEnumType _pType, size_t _n, const void *_v);
 
 METAIO_EXPORT
-bool MET_WriteFieldToFile(METAIO_STREAM::ostream &_fp, const char *_fieldName,
+bool MET_WriteFieldToFile(std::ostream &_fp, const char *_fieldName,
                        MET_ValueEnumType _pType, double _v);
 
 
@@ -426,23 +426,23 @@ bool MET_InitReadField(MET_FieldRecordType * _mf,
 /////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////
 METAIO_EXPORT
-bool MET_Read(METAIO_STREAM::istream &fp,
-           METAIO_STL::vector<MET_FieldRecordType *> * fields,
+bool MET_Read(std::istream &fp,
+           std::vector<MET_FieldRecordType *> * fields,
            char _sepChar='=', bool oneLine=false,
            bool display_warnings=true,
-           METAIO_STL::vector<MET_FieldRecordType *> * newFields=NULL);
+           std::vector<MET_FieldRecordType *> * newFields=NULL);
 
 
 /////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////
 METAIO_EXPORT
-METAIO_STL::string MET_ReadForm(METAIO_STREAM::istream & _fp);
+std::string MET_ReadForm(std::istream & _fp);
 
 METAIO_EXPORT
-METAIO_STL::string MET_ReadType(METAIO_STREAM::istream & _fp);
+std::string MET_ReadType(std::istream & _fp);
 
 METAIO_EXPORT
-char * MET_ReadSubType(METAIO_STREAM::istream & _fp);
+char * MET_ReadSubType(std::istream & _fp);
 
 #if (METAIO_USE_NAMESPACE)
 };

--- a/src/metaVesselTube.cxx
+++ b/src/metaVesselTube.cxx
@@ -73,7 +73,7 @@ MetaVesselTube()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube()" << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube()" << std::endl;
     }
   Clear();
 }
@@ -85,7 +85,7 @@ MetaVesselTube(const char *_headerName)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube()" << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube()" << std::endl;
     }
   Clear();
   Read(_headerName);
@@ -98,7 +98,7 @@ MetaVesselTube(const MetaVesselTube *_VesselTube)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube()" << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube()" << std::endl;
     }
   Clear();
   CopyInfo(_VesselTube);
@@ -111,7 +111,7 @@ MetaVesselTube(unsigned int dim)
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube()" << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube()" << std::endl;
     }
   Clear();
 }
@@ -137,22 +137,22 @@ void MetaVesselTube::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  METAIO_STREAM::cout << "ParentPoint = " << m_ParentPoint
-                      << METAIO_STREAM::endl;
+  std::cout << "ParentPoint = " << m_ParentPoint
+                      << std::endl;
   if(m_Root)
     {
-    METAIO_STREAM::cout << "Root = " << "True" << METAIO_STREAM::endl;
+    std::cout << "Root = " << "True" << std::endl;
     }
   else
     {
-    METAIO_STREAM::cout << "Root = " << "False" << METAIO_STREAM::endl;
+    std::cout << "Root = " << "False" << std::endl;
     }
-  METAIO_STREAM::cout << "Artery = " << m_Artery << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "PointDim = " << m_PointDim << METAIO_STREAM::endl;
-  METAIO_STREAM::cout << "NPoints = " << m_NPoints << METAIO_STREAM::endl;
+  std::cout << "Artery = " << m_Artery << std::endl;
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+  std::cout << "NPoints = " << m_NPoints << std::endl;
   char str[255];
   MET_TypeToString(m_ElementType, str);
-  METAIO_STREAM::cout << "ElementType = " << str << METAIO_STREAM::endl;
+  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaVesselTube::
@@ -231,7 +231,7 @@ Clear()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube: Clear" << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: Clear" << std::endl;
     }
   MetaObject::Clear();
   // Delete the list of pointers to VesselTubes.
@@ -265,8 +265,8 @@ M_SetupReadFields()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube: M_SetupReadFields"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: M_SetupReadFields"
+                        << std::endl;
     }
 
   MetaObject::M_SetupReadFields();
@@ -370,21 +370,21 @@ M_Read()
 {
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube: M_Read: Loading Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: M_Read: Loading Header"
+                        << std::endl;
     }
 
   if(!MetaObject::M_Read())
     {
-    METAIO_STREAM::cout << "MetaVesselTube: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube: M_Read: Parsing Header"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: M_Read: Parsing Header"
+                        << std::endl;
     }
 
   MET_FieldRecordType * mF;
@@ -473,8 +473,8 @@ M_Read()
 
   if(META_DEBUG)
     {
-    METAIO_STREAM::cout << "MetaVesselTube: Parsing point dim"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: Parsing point dim"
+                        << std::endl;
     }
 
   int j;
@@ -617,10 +617,10 @@ M_Read()
     int gc = static_cast<int>(m_ReadStream->gcount());
     if(gc != readSize)
       {
-      METAIO_STREAM::cout << "MetaLine: m_Read: data not read completely"
-                << METAIO_STREAM::endl;
-      METAIO_STREAM::cout << "   ideal = " << readSize
-                << " : actual = " << gc << METAIO_STREAM::endl;
+      std::cout << "MetaLine: m_Read: data not read completely"
+                << std::endl;
+      std::cout << "   ideal = " << readSize
+                << " : actual = " << gc << std::endl;
       delete [] _data;
       delete [] posDim;
       return false;
@@ -944,7 +944,7 @@ M_Read()
       }
 
 
-    const METAIO_STL::string objectType = MET_ReadType(*m_ReadStream);
+    const std::string objectType = MET_ReadType(*m_ReadStream);
     if(objectType.empty())
       {
       char c = ' ';
@@ -982,8 +982,8 @@ M_Write()
 
   if(!MetaObject::M_Write())
     {
-    METAIO_STREAM::cout << "MetaVesselTube: M_Read: Error parsing file"
-                        << METAIO_STREAM::endl;
+    std::cout << "MetaVesselTube: M_Read: Error parsing file"
+                        << std::endl;
     return false;
     }
 
@@ -1140,7 +1140,7 @@ M_Write()
 
       *m_WriteStream << (*it)->m_ID << " ";
 
-      *m_WriteStream << METAIO_STREAM::endl;
+      *m_WriteStream << std::endl;
       ++it;
       }
     }

--- a/src/metaVesselTube.h
+++ b/src/metaVesselTube.h
@@ -75,7 +75,7 @@ class METAIO_EXPORT MetaVesselTube : public MetaObject
   ////
   public:
 
-   typedef METAIO_STL::list<VesselTubePnt*> PointListType;
+   typedef std::list<VesselTubePnt*> PointListType;
     ////
     //
     // Constructors & Destructor


### PR DESCRIPTION
Now that both ITK and VTK require C++11, there is no need for those macros.
Removing them and using std directly makes the code more familiar.