### PR TITLE
BUG: ObjectTypeName must be set in Clear() of derived types.

### DIFF
--- a/src/metaArrow.cxx
+++ b/src/metaArrow.cxx
@@ -146,6 +146,9 @@ Clear()
 {
   if(META_DEBUG) std::cout << "MetaArrow: Clear" << std::endl;
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Arrow");
+
   M_Length = 1;
 
   // zero out direction then set to (1,0,0)
@@ -186,7 +189,6 @@ M_SetupReadFields()
 void MetaArrow::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Arrow");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaBlob.cxx
+++ b/src/metaBlob.cxx
@@ -151,7 +151,11 @@ void MetaBlob::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaBlob: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Blob");
+
   if(META_DEBUG) std::cout << "MetaBlob: Clear: m_NPoints" << std::endl;
   // Delete the list of pointers to blobs.
   PointListType::iterator it = m_PointList.begin();
@@ -220,7 +224,6 @@ ElementType(MET_ValueEnumType _elementType)
 void MetaBlob::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Blob");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaContour.cxx
+++ b/src/metaContour.cxx
@@ -191,7 +191,11 @@ Clear()
     {
     std::cout << "MetaContour: Clear" << std::endl;
     }
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Contour");
+
   m_InterpolationType = MET_NO_INTERPOLATION;
   m_NControlPoints = 0;
   m_NInterpolatedPoints = 0;
@@ -302,7 +306,6 @@ M_SetupWriteFields()
 {
   if(META_DEBUG) std::cout << "MetaContour: M_SetupWriteFields" << std::endl;
 
-  strcpy(m_ObjectTypeName,"Contour");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaDTITube.cxx
+++ b/src/metaDTITube.cxx
@@ -225,7 +225,12 @@ void MetaDTITube::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaDTITube: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Tube");
+  strcpy(m_ObjectSubTypeName,"DTI");
+
   // Delete the list of pointers to DTITubes.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
@@ -288,8 +293,6 @@ M_SetupReadFields()
 void MetaDTITube::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Tube");
-  strcpy(m_ObjectSubTypeName,"DTI");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaEllipse.cxx
+++ b/src/metaEllipse.cxx
@@ -139,7 +139,11 @@ void MetaEllipse::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaEllipse: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Ellipse");
+
   memset(m_Radius, 0, 100*sizeof(float));
 
   for(int i=0; i<m_NDims; i++)
@@ -177,7 +181,6 @@ M_SetupReadFields()
 void MetaEllipse::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Ellipse");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaFEMObject.cxx
+++ b/src/metaFEMObject.cxx
@@ -222,7 +222,11 @@ Clear()
     {
     std::cout << "MetaFEMObject: Clear" << std::endl;
     }
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"FEMObject");
+
   if(META_DEBUG)
     {
     std::cout << "MetaFEMObject: Clear: m_NPoints" << std::endl;
@@ -301,7 +305,6 @@ M_SetupReadFields()
 void MetaFEMObject::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"FEMObject");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaGaussian.cxx
+++ b/src/metaGaussian.cxx
@@ -93,7 +93,11 @@ void MetaGaussian::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaGaussian: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Gaussian");
+
   m_Maximum = 1;
   m_Radius = 1;
   m_Sigma = 1;
@@ -135,7 +139,6 @@ M_SetupReadFields()
 void MetaGaussian::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Gaussian");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaGroup.cxx
+++ b/src/metaGroup.cxx
@@ -88,7 +88,10 @@ void MetaGroup::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaGroup: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Group");
 }
 
 /** Destroy group information */
@@ -118,7 +121,6 @@ M_SetupReadFields()
 void MetaGroup::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Group");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF = new MET_FieldRecordType;

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -507,6 +507,8 @@ void MetaImage::Clear()
 
   MetaObject::Clear();
 
+  strcpy(m_ObjectTypeName,"Image");
+
   // Change the default for this object
   m_BinaryData = true;
 
@@ -2231,7 +2233,6 @@ M_SetupReadFields()
 void MetaImage::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Image");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaLandmark.cxx
+++ b/src/metaLandmark.cxx
@@ -151,7 +151,11 @@ void MetaLandmark::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaLandmark: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Landmark");
+
   if(META_DEBUG) std::cout << "MetaLandmark: Clear: m_NPoints" << std::endl;
   // Delete the list of pointers to tubes.
   PointListType::iterator it = m_PointList.begin();
@@ -220,7 +224,6 @@ ElementType(MET_ValueEnumType _elementType)
 void MetaLandmark::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Landmark");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaLine.cxx
+++ b/src/metaLine.cxx
@@ -159,7 +159,11 @@ void MetaLine::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaLine: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Line");
+
   m_NPoints = 0;
     // Delete the list of pointers to lines.
   PointListType::iterator it = m_PointList.begin();
@@ -217,7 +221,6 @@ M_SetupReadFields()
 void MetaLine::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Line");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaMesh.cxx
+++ b/src/metaMesh.cxx
@@ -196,7 +196,11 @@ void MetaMesh::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaMesh: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Mesh");
+
   if(META_DEBUG) std::cout << "MetaMesh: Clear: m_NPoints" << std::endl;
 
   // Delete the list of pointers to points.
@@ -320,7 +324,6 @@ M_SetupReadFields()
 void MetaMesh::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Mesh");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaScene.cxx
+++ b/src/metaScene.cxx
@@ -443,7 +443,11 @@ Clear()
     {
     std::cout << "MetaScene: Clear" << std::endl;
     }
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Scene");
+  //
   // Delete the list of pointers to objects in the scene.
   ObjectListType::iterator it = m_ObjectList.begin();
   while(it != m_ObjectList.end())
@@ -501,7 +505,6 @@ M_SetupWriteFields()
     m_Fields.push_back(mF);
     }
 
-  strcpy(m_ObjectTypeName,"Scene");
   mF = new MET_FieldRecordType;
   MET_InitWriteField(mF, "ObjectType", MET_STRING, strlen(m_ObjectTypeName),
     m_ObjectTypeName);

--- a/src/metaSurface.cxx
+++ b/src/metaSurface.cxx
@@ -150,7 +150,11 @@ void MetaSurface::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaSurface: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Surface");
+
   m_NPoints = 0;
   // Delete the list of pointers to tubes.
   PointListType::iterator it = m_PointList.begin();
@@ -207,7 +211,6 @@ M_SetupWriteFields()
 {
   if(META_DEBUG) std::cout << "MetaSurface: M_SetupWriteFields" << std::endl;
 
-  strcpy(m_ObjectTypeName,"Surface");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaTransform.cxx
+++ b/src/metaTransform.cxx
@@ -87,7 +87,11 @@ void MetaTransform::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaTransform: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Transform");
+
   delete parameters;
   parameters = nullptr;
   parametersDimension = 0;
@@ -153,7 +157,6 @@ M_SetupReadFields()
 void MetaTransform::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Transform");
   MetaObject::M_SetupWriteFields();
 
   // We don't want to write the matrix and the offset

--- a/src/metaTube.cxx
+++ b/src/metaTube.cxx
@@ -194,7 +194,11 @@ void MetaTube::
 Clear()
 {
   if(META_DEBUG) std::cout << "MetaTube: Clear" << std::endl;
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Tube");
+
   // Delete the list of pointers to tubes.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
@@ -257,7 +261,6 @@ M_SetupReadFields()
 void MetaTube::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Tube");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaTubeGraph.cxx
+++ b/src/metaTubeGraph.cxx
@@ -155,7 +155,11 @@ Clear()
     {
     std::cout << "MetaTubeGraph: Clear" << std::endl;
     }
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"TubeGraph");
+
   // Delete the list of pointers to tubes.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
@@ -215,7 +219,6 @@ M_SetupReadFields()
 void MetaTubeGraph::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"TubeGraph");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;

--- a/src/metaVesselTube.cxx
+++ b/src/metaVesselTube.cxx
@@ -233,7 +233,12 @@ Clear()
     {
     std::cout << "MetaVesselTube: Clear" << std::endl;
     }
+
   MetaObject::Clear();
+
+  strcpy(m_ObjectTypeName,"Tube");
+  strcpy(m_ObjectSubTypeName,"Vessel");
+
   // Delete the list of pointers to VesselTubes.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
@@ -305,8 +310,6 @@ M_SetupReadFields()
 void MetaVesselTube::
 M_SetupWriteFields()
 {
-  strcpy(m_ObjectTypeName,"Tube");
-  strcpy(m_ObjectSubTypeName,"Vessel");
   MetaObject::M_SetupWriteFields();
 
   MET_FieldRecordType * mF;


### PR DESCRIPTION
Previously ObjectTypeName was only set for metaObject (top level) in
the Clear() function and was set in the M_SetupWriteFields() of
derived classes.  Therefore, the value was fixed at "Object" until
the write command was called or a file was read (that then set the
type).

In this fixed version, the ObjectTypeName value is set in the Clear()
function of metaObject and its derived classes (and not in the
M_SetupWriteFields() function).  Therefore, its value is correct
as soon as the class is instantiated.