### PR TITLE
COMP: remove pre-VS2015 backwards compatibility definition of snprintf

### DIFF
--- a/src/metaTypes.h
+++ b/src/metaTypes.h
@@ -193,10 +193,6 @@ typedef struct
                                   //   meta data
    } MET_FieldRecordType;
 
-// Emulate C++11 snprintf on old MSVC.
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#define snprintf _snprintf
-#endif
 
 #if (METAIO_USE_NAMESPACE)
 };


### PR DESCRIPTION
We can do this now that both VTK and ITK require C++11.