### PR TITLE
ENH: Parse() should handle char *argv[] as const

### DIFF
--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -1698,7 +1698,7 @@ ExportGAD(bool dynamic)
 
 
 /** Parse the command line */
-bool MetaCommand::Parse(int argc, const char* argv[])
+bool MetaCommand::Parse(int argc, char** const argv)
 {
   m_GotXMLFlag = false;
   m_ExecutableName = argv[0];

--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -1698,7 +1698,7 @@ ExportGAD(bool dynamic)
 
 
 /** Parse the command line */
-bool MetaCommand::Parse(int argc, char* argv[])
+bool MetaCommand::Parse(int argc, const char* argv[])
 {
   m_GotXMLFlag = false;
   m_ExecutableName = argv[0];

--- a/src/metaCommand.h
+++ b/src/metaCommand.h
@@ -183,7 +183,7 @@ public:
 
   bool OptionExistsByMinusTag(std::string minusTag);
 
-  bool Parse(int argc, const char* argv[]);
+  bool Parse(int argc, char** const argv);
 
   /** Given an XML buffer fill in the command line arguments */
   bool ParseXML(const char* buffer);

--- a/src/metaCommand.h
+++ b/src/metaCommand.h
@@ -183,7 +183,7 @@ public:
 
   bool OptionExistsByMinusTag(std::string minusTag);
 
-  bool Parse(int argc, char* argv[]);
+  bool Parse(int argc, const char* argv[]);
 
   /** Given an XML buffer fill in the command line arguments */
   bool ParseXML(const char* buffer);


### PR DESCRIPTION
Added const to function arg.

All MetaIO test pass.