### PR TITLE
Tube point fields

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,12 +55,15 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(sources
   metaUtils.cxx
+  metaArray.cxx
   metaArrow.cxx
   metaBlob.cxx
   metaCommand.cxx
   metaContour.cxx
   metaDTITube.cxx
   metaEllipse.cxx
+  metaFEMObject.cxx
+  metaForm.cxx
   metaGroup.cxx
   metaGaussian.cxx
   metaImage.cxx
@@ -70,15 +73,13 @@ set(sources
   metaMesh.cxx
   metaObject.cxx
   metaOutput.cxx
+  metaPointObject.cxx
   metaScene.cxx
   metaSurface.cxx
   metaTube.cxx
-  metaVesselTube.cxx
   metaTransform.cxx
   metaTubeGraph.cxx
-  metaForm.cxx
-  metaArray.cxx
-  metaFEMObject.cxx
+  metaVesselTube.cxx
   )
 
 set(headers
@@ -104,11 +105,12 @@ set(headers
   metaMesh.h
   metaObject.h
   metaOutput.h
+  metaPointObject.h
   metaScene.h
   metaSurface.h
+  metaTube.h
   metaTransform.h
   metaTubeGraph.h
-  metaTube.h
   metaTypes.h
   metaUtils.h
   metaVesselTube.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,6 @@ set(sources
   metaMesh.cxx
   metaObject.cxx
   metaOutput.cxx
-  metaPointObject.cxx
   metaScene.cxx
   metaSurface.cxx
   metaTube.cxx
@@ -105,7 +104,6 @@ set(headers
   metaMesh.h
   metaObject.h
   metaOutput.h
-  metaPointObject.h
   metaScene.h
   metaSurface.h
   metaTube.h

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -1506,7 +1506,6 @@ M_SetupWriteFields()
 bool MetaObject::
 M_Read()
 {
-
   this->ClearAdditionalFields();
 
   if(!MET_Read(*m_ReadStream, &m_Fields, '=', false, true,
@@ -1781,11 +1780,11 @@ M_Read()
       }
     }
 
-   // Set the read record field in the m_UserDefinedWriteFields
-   FieldsContainerType::iterator  it  = m_UserDefinedReadFields.begin();
-   FieldsContainerType::iterator  end = m_UserDefinedReadFields.end();
-   while( it != end )
-   {
+  // Set the read record field in the m_UserDefinedWriteFields
+  FieldsContainerType::iterator  it  = m_UserDefinedReadFields.begin();
+  FieldsContainerType::iterator  end = m_UserDefinedReadFields.end();
+  while( it != end )
+  {
      mF = MET_GetFieldRecord((*it)->name, &m_Fields);
      //
      // DON'T put the same cross-linked element from the UD readFields
@@ -1806,7 +1805,7 @@ M_Read()
        m_UserDefinedWriteFields.push_back(mF);
        }
      ++it;
-   }
+  }
 
   return true;
 }

--- a/src/metaScene.cxx
+++ b/src/metaScene.cxx
@@ -157,12 +157,8 @@ Read(const char *_headerName)
 
   M_PrepareNewReadStream();
 
-#ifdef __sgi
-  m_ReadStream->open(m_FileName, std::ios::in);
-#else
   m_ReadStream->open(m_FileName, std::ios::binary
                                  | std::ios::in);
-#endif
 
   if(!m_ReadStream->rdbuf()->is_open())
     {

--- a/src/metaTube.cxx
+++ b/src/metaTube.cxx
@@ -28,52 +28,216 @@ namespace METAIO_NAMESPACE {
 TubePnt::
 TubePnt(int dim)
 {
-  m_Dim = dim;
-  m_X = new float[m_Dim];
-  m_T = new float[m_Dim];
-  m_V1= new float[m_Dim];
-  m_V2= new float[m_Dim];
-  for(unsigned int i=0;i<m_Dim;i++)
+  m_NDims = dim;
+
+  m_ID = -1;
+
+  m_X = new float[m_NDims];
+  unsigned int i=0;
+  for(i=0;i<m_NDims;i++)
     {
     m_X[i] = 0;
-    m_V1[i]= 0;
-    m_V2[i]= 0;
-    m_T[i]= 0;
     }
-  m_Alpha1=0;
-  m_Alpha2=0;
-  m_Alpha3=0;
-  m_R=0;
-  m_Medialness=0;
-  m_Ridgeness=0;
-  m_Branchness=0;
-  m_Curvature=0;
-  m_Levelness=0;
-  m_Roundness=0;
-  m_Intensity=0;
-  m_Mark=false;
 
-  //Color is red by default
-  m_Color[0]=1.0f;
-  m_Color[1]=0.0f;
-  m_Color[2]=0.0f;
-  m_Color[3]=1.0f;
-  m_ID = -1;
+  for(i=0;i<4;i++)
+    {
+    m_Color[i] = 1;
+    }
+
+  m_Mark = false;
+
+  m_T = new float[m_NDims];
+  m_V1 = new float[m_NDims];
+  m_V2 = new float[m_NDims];
+  for(unsigned int i=0;i<m_NDims;i++)
+    {
+    m_T[i] = 0;
+    m_V1[i] = 0;
+    m_V2[i] = 0;
+    }
+  m_Alpha1 = 0;
+  m_Alpha2 = 0;
+  m_Alpha3 = 0;
+
+  m_R = 0;
+  m_Medialness = 0;
+  m_Ridgeness = 0;
+  m_Branchness = 0;
+  m_Curvature = 0;
+  m_Levelness = 0;
+  m_Roundness = 0;
+  m_Intensity = 0;
+
+  m_ExtraFields.clear();
+}
+
+TubePnt::
+TubePnt(const TubePnt * _tubePnt)
+{
+  CopyInfo( _tubePnt );
 }
 
 TubePnt::
 ~TubePnt()
 {
-  delete []m_X;
-  delete []m_V1;
-  delete []m_V2;
-  delete []m_T;
+  delete [] m_X;
+  delete [] m_T;
+  delete [] m_V1;
+  delete [] m_V2;
+
+  m_ExtraFields.clear();
+}
+
+void TubePnt::
+CopyInfo( const TubePnt * _tubePnt )
+{
+  delete [] m_X;
+  delete [] m_T;
+  delete [] m_V1;
+  delete [] m_V2;
+
+  m_ExtraFields.clear();
+
+  m_NDims = _tubePnt->m_NDims;
+
+  m_X = new float[m_NDims];
+  m_T = new float[m_NDims];
+  m_V1 = new float[m_NDims];
+  m_V2 = new float[m_NDims];
+  for( unsigned int i=0; i<m_NDims; ++i )
+    {
+    m_X[i] = _tubePnt->m_X[i];
+    m_T[i] = _tubePnt->m_T[i];
+    m_V1[i] = _tubePnt->m_V1[i];
+    m_V2[i] = _tubePnt->m_V2[i];
+    }
+  m_Alpha1 = _tubePnt->m_Alpha1;
+  m_Alpha2 = _tubePnt->m_Alpha2;
+  m_Alpha3 = _tubePnt->m_Alpha3;
+  m_R = _tubePnt->m_R;
+  m_Medialness = _tubePnt->m_Medialness;
+  m_Ridgeness = _tubePnt->m_Ridgeness;
+  m_Branchness = _tubePnt->m_Branchness;
+  m_Curvature = _tubePnt->m_Curvature;
+  m_Levelness = _tubePnt->m_Levelness;
+  m_Roundness = _tubePnt->m_Roundness;
+  m_Intensity = _tubePnt->m_Intensity;
+
+  for( unsigned int i=0; i<4; ++i )
+    {
+    m_Color[i] = _metaPoint->m_Color[i];
+    }
+  m_Mark = _metaPoint->m_Mark;
+
+  FieldListType::const_iterator it = _metaPoint->m_ExtraFields.begin();
+  FieldListType::const_iterator itEnd = _metaPoint->m_ExtraFields.end();
+  while(it != itEnd)
+    {
+    m_ExtraFields.push_back( *it );
+    ++it;
+    }
+}
+const TubePnt::FieldListType & TubePnt::
+GetExtraFields() const
+{
+  return m_ExtraFields;
+}
+
+int TubePnt::
+GetNumberOfExtraFields() const
+{
+  return m_ExtraFields.size();
+}
+
+void TubePnt::
+SetNumberOfExtraFields( int size )
+{
+  m_ExtraFields.resize( size );
+}
+
+void TubePnt::
+SetField( int indx, const char * name, float value )
+{
+  FieldType field(name,value);
+  m_ExtraFields[ indx ] = field;
+}
+
+void TubePnt::
+SetField( const char * name, float value )
+{
+  int indx = this->GetFieldIndex( name );
+  if( indx >= 0 )
+    {
+    m_ExtraFields[indx].second = value;
+    }
+  else
+    {
+    this->AddField( name, value );
+    }
+}
+
+void TubePnt::
+AddField(const char* name, float value)
+{
+  int indx = this->GetFieldIndex( name );
+  if( indx != -1 )
+    {
+    m_ExtraFields[indx].second = value;
+    }
+  else
+    {
+    FieldType field(name,value);
+    m_ExtraFields.push_back(field);
+    }
+}
+
+int TubePnt::
+GetFieldIndex(const char* name) const
+{
+  unsigned int count = 0;
+  FieldListType::const_iterator it = m_ExtraFields.begin();
+  FieldListType::const_iterator itEnd = m_ExtraFields.end();
+  while(it != itEnd)
+    {
+    if(!strcmp((*it).first.c_str(), name))
+      {
+      return count;
+      }
+    ++it;
+    ++count;
+    }
+  return -1;
+}
+
+float TubePnt::
+GetField(int indx) const
+{
+  if( indx >= 0 && indx < m_ExtraFields.size() )
+    {
+    return m_ExtraFields[indx].second;
+    }
+  return -1;
+}
+
+float TubePnt::
+GetField(const char* name) const
+{
+  FieldListType::const_iterator it = m_ExtraFields.begin();
+  FieldListType::const_iterator itEnd = m_ExtraFields.end();
+  while(it != itEnd)
+    {
+    if(!strcmp((*it).first.c_str(),name))
+      {
+      return (*it).second;
+      }
+    ++it;
+    }
+  return -1;
 }
 
 /** MetaTube Constructors */
 MetaTube::
 MetaTube()
-:MetaObject()
 {
   if(META_DEBUG)
     {
@@ -124,14 +288,14 @@ MetaTube(unsigned int dim)
 MetaTube::
 ~MetaTube()
 {
-  // Delete the list of pointers to Tubes.
+  // Delete the list of pointers to PointObject.
   PointListType::iterator it = m_PointList.begin();
   while(it != m_PointList.end())
-    {
-    TubePnt* pnt = *it;
+  {
+    TubePnt * pnt = *it;
     ++it;
     delete pnt;
-    }
+  }
   m_PointList.clear();
   M_Destroy();
 }
@@ -141,8 +305,17 @@ void MetaTube::
 PrintInfo() const
 {
   MetaObject::PrintInfo();
-  std::cout << "ParentPoint = " << m_ParentPoint
-                      << std::endl;
+
+  std::cout << "PointDim = " << m_PointDim << std::endl;
+
+  std::cout << "NPoints = " << m_NPoints << std::endl;
+
+  char str[255];
+  MET_TypeToString(m_ElementType, str);
+  std::cout << "ElementType = " << str << std::endl;
+
+  std::cout << "ParentPoint = " << m_ParentPoint << std::endl;
+
   if(m_Root)
     {
     std::cout << "Root = " << "True" << std::endl;
@@ -151,82 +324,28 @@ PrintInfo() const
     {
     std::cout << "Root = " << "False" << std::endl;
     }
+
   std::cout << "Artery = " << m_Artery << std::endl;
-  std::cout << "PointDim = " << m_PointDim << std::endl;
-  std::cout << "NPoints = " << m_NPoints << std::endl;
-  char str[255];
-  MET_TypeToString(m_ElementType, str);
-  std::cout << "ElementType = " << str << std::endl;
 }
 
 void MetaTube::
-CopyInfo(const MetaObject * _object)
+CopyInfo(const MetaTube * _object)
 {
+  Clear();
+
   MetaObject::CopyInfo(_object);
-}
 
+  PointListType::const_iterator it = _object->GetPoints().begin();
+  while(it != _object->GetPoints().end())
+    {
+    TubePnt * pnt = new TubePnt( *it );
+    m_PointList.push_back(pnt);
+    ++it;
+    }
 
-
-void MetaTube::
-PointDim(const char* pointDim)
-{
-  strcpy(m_PointDim,pointDim);
-}
-
-const char* MetaTube::
-PointDim() const
-{
-  return m_PointDim;
-}
-
-void MetaTube::
-NPoints(int npnt)
-{
-  m_NPoints = npnt;
-}
-
-int MetaTube::
-NPoints() const
-{
-  return m_NPoints;
-}
-
-void MetaTube::
-Root(bool root)
-{
-  m_Root = root;
-}
-
-bool MetaTube::
-Root() const
-{
-  return m_Root;
-}
-
-
-void MetaTube::
-Artery(bool artery)
-{
-  m_Artery = artery;
-}
-
-bool MetaTube::
-Artery() const
-{
-  return m_Artery;
-}
-
-
-void  MetaTube::
-ParentPoint(int parentpoint)
-{
-  m_ParentPoint = parentpoint;
-}
-
-int MetaTube::
-ParentPoint() const
-{
-  return m_ParentPoint;
+  m_ParentPoint = _object->ParentPoint();
+  m_Artery = _object->Artery();
+  m_Root = _object->Root();
 }
 
 /** Clear Tube information */
@@ -240,26 +359,55 @@ Clear()
 
   MetaObject::Clear();
 
-  strcpy(m_ObjectTypeName,"Tube");
-  strcpy(m_ObjectSubTypeName,"");
+  strcpy(m_ObjectTypeName, "Tube");
+  strcpy(m_ObjectSubTypeName, "");
 
-  // Delete the list of pointers to Tubes.
-  PointListType::iterator it = m_PointList.begin();
-  while(it != m_PointList.end())
-    {
-    TubePnt* pnt = *it;
-    ++it;
-    delete pnt;
-    }
-  m_PointList.clear();
+  m_ElementType = MET_FLOAT;
 
-  m_ParentPoint= -1;
+  m_ParentPoint = -1;
   m_Root = false;
   m_Artery = true;
+
+  // Delete the list of pointers to PointObjects.
+  PointListType::iterator it = m_PointList.begin();
+  while(it != m_PointList.end())
+  {
+    TubePnt * pnt = *it;
+    ++it;
+    delete pnt;
+  }
+  m_PointList.clear();
+
   m_NPoints = 0;
-  strcpy(m_PointDim, "x y z r rn mn bn cv lv ro in mk v1x v1y v1z v2x v2y v2z tx ty tz a1 a2 a3 red green blue alpha id");
-  m_ElementType = MET_FLOAT;
+  if( m_NDims == 2 )
+    {
+    m_PointDim = "id x y red green blue alpha mark r rn mn bn cv lv ro in tx ty v1x v1y a1 a2";
+    }
+  else
+    {
+    m_PointDim = "id x y z red green blue alpha mark r rn mn bn cv lv ro in tx ty tz v1x v1y v1z v2x v2y v2z a1 a2 a3";
+    }
+
 }
+
+const char* MetaPointObject::
+PointDim() const
+{
+  return m_PointDim.c_str();
+}
+
+void MetaPointObject::
+NPoints(int npnt)
+{
+  m_NPoints = npnt;
+}
+
+int MetaPointObject::
+NPoints() const
+{
+  return m_NPoints;
+}
+
 
 /** Destroy Tube information */
 void MetaTube::
@@ -281,8 +429,6 @@ M_SetupReadFields()
   MetaObject::M_SetupReadFields();
 
   MET_FieldRecordType * mF;
-
-  // int nDimsRecNum = MET_GetFieldRecordNumber("NDims", &m_Fields);
 
   mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "ParentPoint", MET_INT, false);
@@ -308,7 +454,6 @@ M_SetupReadFields()
   MET_InitReadField(mF, "Points", MET_NONE, true);
   mF->terminateRead = true;
   m_Fields.push_back(mF);
-
 }
 
 void MetaTube::
@@ -321,7 +466,7 @@ M_SetupWriteFields()
   if(m_ParentPoint>=0 && m_ParentID>=0)
     {
     mF = new MET_FieldRecordType;
-    MET_InitWriteField(mF, "ParentPoint", MET_INT,m_ParentPoint);
+    MET_InitWriteField(mF, "ParentPoint", MET_INT, m_ParentPoint);
     m_Fields.push_back(mF);
     }
 
@@ -353,29 +498,76 @@ M_SetupWriteFields()
 
   if( m_NDims == 2 )
     {
-    strcpy(m_PointDim, "x y r rn mn bn cv lv ro in mk v1x v1y tx ty a1 a2 red green blue alpha id");
+    m_PointDim = "id x y red green blue alpha mark r rn mn bn cv lv ro in tx ty v1x v1y a1 a2";
     }
   else
     {
-    strcpy(m_PointDim, "x y z r rn mn bn cv lv ro in mk v1x v1y v1z v2x v2y v2z tx ty tz a1 a2 a3 red green blue alpha id");
+    m_PointDim = "id x y z red green blue alpha mark r rn mn bn cv lv ro in tx ty tz v1x v1y v1z v2x v2y v2z a1 a2 a3";
     }
-  mF = new MET_FieldRecordType;
-  MET_InitWriteField(mF, "PointDim", MET_STRING,
-                         strlen(m_PointDim),m_PointDim);
-  m_Fields.push_back(mF);
 
+  // All the points in the tube have the same number of fields
+  const MetaPoint::FieldListType & extraList =
+    (*(m_PointList.begin()))->GetExtraFields();
+  MetaPoint::FieldListType::const_iterator itFields = extraList.begin();
+  MetaPoint::FieldListType::const_iterator itFieldsEnd = extraList.end();
+  while(itFields !=  itFieldsEnd)
+    {
+    m_PointDim += " ";
+    m_PointDim += (*itFields).first;
+    ++itFields;
+    }
+
+  mF = MET_GetFieldRecord("PointDim", &m_Fields);
+  MET_InitWriteField(mF, "PointDim", MET_STRING, m_PointDim.size(),
+    m_PointDim.c_str() );
+  
   m_NPoints = (int)m_PointList.size();
   mF = new MET_FieldRecordType;
-  MET_InitWriteField(mF, "NPoints", MET_INT,m_NPoints);
+  MET_InitWriteField(mF, "NPoints", MET_INT, m_NPoints);
   m_Fields.push_back(mF);
 
   mF = new MET_FieldRecordType;
   MET_InitWriteField(mF, "Points", MET_NONE);
   m_Fields.push_back(mF);
-
 }
 
+/** Return the position given the name of the field */
+int MetaTube::
+M_GetPosition(const char* name, std::vector<bool> & used) const
+{
+  std::vector<PositionType>::const_iterator it = m_Positions.begin();
+  std::vector<bool>::iterator itUsed = used.begin();
+  std::vector<PositionType>::const_iterator itEnd = m_Positions.end();
+  while(it != itEnd)
+    {
+    if(!strcmp((*it).first.c_str(),name))
+      {
+      *itUsed = true;
+      return (*it).second;
+      }
+    ++it;
+    ++itUsed;
+    }
 
+  return -1;
+}
+
+float MetaTube::
+M_GetFloatFromBinaryData( int pos, char * _data, int readSize ) const
+{
+  if( pos >= 0 && pos < readSize )
+    {
+    float tf;
+    char * const num = (char *)(&tf);
+    for(unsigned int k=0; k<sizeof(float) && pos+k<readSize; k++)
+      {
+      num[k] = _data[pos+k];
+      }
+    MET_SwapByteIfSystemMSB(&tf, MET_FLOAT);
+    return (float)tf;
+    }
+  return -1;
+}
 
 bool MetaTube::
 M_Read()
@@ -440,206 +632,111 @@ M_Read()
   mF = MET_GetFieldRecord("NPoints", &m_Fields);
   if(mF->defined)
     {
-    m_NPoints= (int)mF->value[0];
+    m_NPoints = (int)mF->value[0];
+    }
+
+  mF = MET_GetFieldRecord("ElementType", &m_Fields);
+  if(mF->defined)
+    {
+    MET_StringToType((char *)(mF->value), &m_ElementType);
     }
 
   mF = MET_GetFieldRecord("PointDim", &m_Fields);
   if(mF->defined)
     {
-    strcpy(m_PointDim,(char *)(mF->value));
+    strcpy(m_PointDim, (char *)(mF->value));
     }
-
-
-  int* posDim= new int[m_NDims];
-  int i;
-  for(i= 0; i < m_NDims; i++)
-    {
-    posDim[i] = -1;
-    }
-  int posR = -1;
-  int posRn = -1;
-  int posMn = -1;
-  int posBn = -1;
-  int posCv = -1;
-  int posLv = -1;
-  int posRo = -1;
-  int posIn = -1;
-  int posMk = -1;
-  int posV1x = -1;
-  int posV1y = -1;
-  int posV1z = -1;
-  int posV2x = -1;
-  int posV2y = -1;
-  int posV2z = -1;
-  int posTx = -1;
-  int posTy = -1;
-  int posTz = -1;
-  int posA1 = -1;
-  int posA2 = -1;
-  int posA3 = -1;
-  int posRed = -1;
-  int posGreen = -1;
-  int posBlue = -1;
-  int posAlpha = -1;
-  int posID = -1;
 
   int pntDim;
   char** pntVal = nullptr;
-  MET_StringToWordArray(m_PointDim, &pntDim, &pntVal);
+  char pointDim[4096];
+
+  for(unsigned t = 0; t<this->m_PointDim.size(); t++)
+    {
+    pointDim[t] = this->m_PointDim[t];
+    }
+  pointDim[m_PointDim.size()] = '\0';
+
+  MET_StringToWordArray(pointDim, &pntDim, &pntVal);
 
   if(META_DEBUG)
     {
-    std::cout << "MetaTube: Parsing point dim"
-                        << std::endl;
+    std::cout << "MetaPointObject: Parsing point dim" << std::endl;
     }
 
-  int j;
-  for(j = 0; j < pntDim; j++)
+  m_Positions.clear();
+  std::vector<bool> positionUsed;
+  for(unsigned int i=0; i<pntDim; i++)
     {
-    if(!strcmp(pntVal[j], "x") || !strcmp(pntVal[j], "X"))
-      {
-      posDim[0] = j;
-      }
-    if(!strcmp(pntVal[j], "y") || !strcmp(pntVal[j], "Y"))
-      {
-      posDim[1] = j;
-      }
-    if(!strcmp(pntVal[j], "z") || !strcmp(pntVal[j], "Z"))
-      {
-      posDim[2] = j;
-      }
-    if(((char *)pntVal[j])[0] == 'w' || ((char *)pntVal[j])[0] == 'W')
-      {
-      posDim[(int)pntVal[j][1]+3] = j;
-      }
-    if(!strcmp(pntVal[j], "s") || !strcmp(pntVal[j], "S") ||
-      !strcmp(pntVal[j], "r") || !strcmp(pntVal[j], "R") ||
-      !strcmp(pntVal[j], "rad") || !strcmp(pntVal[j], "Rad") ||
-      !strcmp(pntVal[j], "radius") || !strcmp(pntVal[j], "Radius"))
-      {
-      posR = j;
-      }
-
-    if(!strcmp(pntVal[j], "rn") || !strcmp(pntVal[j], "RN"))
-      {
-      posRn = j;
-      }
-    if(!strcmp(pntVal[j], "mn") || !strcmp(pntVal[j], "MN"))
-      {
-      posMn = j;
-      }
-    if(!strcmp(pntVal[j], "bn") || !strcmp(pntVal[j], "BN"))
-      {
-      posBn = j;
-      }
-    if(!strcmp(pntVal[j], "cv") || !strcmp(pntVal[j], "CV"))
-      {
-      posCv = j;
-      }
-    if(!strcmp(pntVal[j], "lv") || !strcmp(pntVal[j], "LV"))
-      {
-      posLv = j;
-      }
-    if(!strcmp(pntVal[j], "Ro") || !strcmp(pntVal[j], "RO"))
-      {
-      posRo = j;
-      }
-    if(!strcmp(pntVal[j], "in") || !strcmp(pntVal[j], "IN"))
-      {
-      posIn = j;
-      }
-    if(!strcmp(pntVal[j], "mk") || !strcmp(pntVal[j], "MK"))
-      {
-      posMk = j;
-      }
-    if(!strcmp(pntVal[j], "v1x"))
-      {
-      posV1x = j;
-      }
-    if(!strcmp(pntVal[j], "v1y"))
-      {
-      posV1y = j;
-      }
-    if(!strcmp(pntVal[j], "v1z"))
-      {
-      posV1z = j;
-      }
-    if(!strcmp(pntVal[j], "v2x"))
-      {
-      posV2x = j;
-      }
-    if(!strcmp(pntVal[j], "v2y"))
-      {
-      posV2y = j;
-      }
-    if(!strcmp(pntVal[j], "v2z"))
-      {
-      posV2z = j;
-      }
-    if(!strcmp(pntVal[j], "tx"))
-      {
-      posTx = j;
-      }
-    if(!strcmp(pntVal[j], "ty"))
-      {
-      posTy = j;
-      }
-    if(!strcmp(pntVal[j], "tz"))
-      {
-      posTz = j;
-      }
-    if(!strcmp(pntVal[j], "a1"))
-      {
-      posA1 = j;
-      }
-    if(!strcmp(pntVal[j], "a2"))
-      {
-      posA2 = j;
-      }
-    if(!strcmp(pntVal[j], "a3"))
-      {
-      posA3 = j;
-      }
-    if(!strcmp(pntVal[j], "red"))
-      {
-      posRed = j;
-      }
-    if(!strcmp(pntVal[j], "green"))
-      {
-      posGreen = j;
-      }
-    if(!strcmp(pntVal[j], "blue"))
-      {
-      posBlue = j;
-      }
-    if(!strcmp(pntVal[j], "alpha"))
-      {
-      posAlpha = j;
-      }
-    if(!strcmp(pntVal[j], "id") || !strcmp(pntVal[j], "ID"))
-      {
-      posID = j;
-      }
+    PositionType p(pntVal[i], i);
+    m_Positions.push_back(p);
+    positionUsed.push_back(false);
     }
 
-  for(i=0;i<pntDim;i++)
+  for(unsigned int i=0; i<pntDim; i++)
     {
     delete [] pntVal[i];
     }
   delete [] pntVal;
 
-  float v[50];
+  float v[100];
 
   if(m_Event)
     {
     m_Event->StartReading(m_NPoints);
     }
 
+  int posId = M_GetPosition("id", positionUsed);
+  int posX = M_GetPosition("x", positionUsed);
+  int posY = M_GetPosition("y", positionUsed);
+  int posZ = M_GetPosition("z", positionUsed);
+  int posRed = M_GetPosition("red", positionUsed);
+  int posGreen = M_GetPosition("green", positionUsed);
+  int posBlue = M_GetPosition("blue", positionUsed);
+  int posAlpha = M_GetPosition("alpha", positionUsed);
+  int posMark = M_GetPosition("mark", positionUsed);
+  if( posMark == -1 )
+    { posMark = M_GetPosition("mk", positionUsed); }
+  int posR = M_GetPosition("r", positionUsed);
+  if( posR == -1 )
+    { posR = M_GetPosition("R", positionUsed); }
+  else if( posR == -1 )
+    { posR = M_GetPosition("radius", positionUsed); }
+  else if( posR == -1 )
+    { posR = M_GetPosition("Radius", positionUsed); }
+  else if( posR == -1 )
+    { posR = M_GetPosition("rad", positionUsed); }
+  else if( posR == -1 )
+    { posR = M_GetPosition("Rad", positionUsed); }
+  else if( posR == -1 )
+    { posR = M_GetPosition("s", positionUsed); }
+  else if( posR == -1 )
+    { posR = M_GetPosition("S", positionUsed); }
+  int posRn = M_GetPosition("rn", positionUsed);
+  int posMn = M_GetPosition("mn", positionUsed);
+  int posBn = M_GetPosition("bn", positionUsed);
+  int posCv = M_GetPosition("cv", positionUsed);
+  int posLv = M_GetPosition("lv", positionUsed);
+  int posRo = M_GetPosition("ro", positionUsed);
+  int posIn = M_GetPosition("in", positionUsed);
+  int posTx = M_GetPosition("tx", positionUsed);
+  int posTy = M_GetPosition("ty", positionUsed);
+  int posTz = M_GetPosition("tz", positionUsed);
+  int posV1x = M_GetPosition("v1x", positionUsed);
+  int posV1y = M_GetPosition("v1y", positionUsed);
+  int posV1z = M_GetPosition("v1z", positionUsed);
+  int posV2x = M_GetPosition("v2x", positionUsed);
+  int posV2y = M_GetPosition("v2y", positionUsed);
+  int posV2z = M_GetPosition("v2z", positionUsed);
+  int posA1 = M_GetPosition("a1", positionUsed);
+  int posA2 = M_GetPosition("a2", positionUsed);
+  int posA3 = M_GetPosition("a3", positionUsed);
+
   if(m_BinaryData)
     {
     int elementSize;
     MET_SizeOfType(m_ElementType, &elementSize);
-    int readSize = m_NPoints*(m_NDims*(2+m_NDims)+10)*elementSize;
+    int readSize = m_NPoints*pntDim*elementSize;
 
     char* _data = new char[readSize];
     m_ReadStream->read((char *)_data, readSize);
@@ -652,412 +749,310 @@ M_Read()
       std::cout << "   ideal = " << readSize
                 << " : actual = " << gc << std::endl;
       delete [] _data;
-      delete [] posDim;
       return false;
       }
 
-    i=0;
-    int d;
-    unsigned int k;
-    for(j=0; j<(int)m_NPoints; j++)
+    for(unsigned int j=0; j<m_NPoints; j++)
       {
-      TubePnt* pnt = new TubePnt(m_NDims);
+      MetaPoint* pnt = new MetaPoint(m_NDims);
 
-      for(j = 0; j < pntDim; j++)
+      if( posId >= 0 )
         {
-        if( j == posDim[0] )
+        pnt->m_ID = M_GetFloatFromBinaryData( posId, _data, readSize );
+        }
+      if( posX >= 0 )
+        {
+        pnt->m_X[0] = M_GetFloatFromBinaryData( posX, _data, readSize );
+        }
+      if( posY >= 0 )
+        {
+        pnt->m_X[1] = M_GetFloatFromBinaryData( posY, _data, readSize );
+        }
+      if( m_NDims == 3 && posZ >= 0 )
+        {
+        pnt->m_X[2] = M_GetFloatFromBinaryData( posZ, _data, readSize );
+        }
+      if( posRed >= 0 )
+        {
+        pnt->m_Color[0] = M_GetFloatFromBinaryData( posRed, _data, readSize );
+        }
+      if( posGreen >= 0 )
+        {
+        pnt->m_Color[1] = M_GetFloatFromBinaryData( posGreen, _data, readSize );
+        }
+      if( posBlue >= 0 )
+        {
+        pnt->m_Color[2] = M_GetFloatFromBinaryData( posBlue, _data, readSize );
+        }
+      if( posMark >= 0 )
+        {
+        if( M_GetFloatFromBinaryData( posMark, _data, readSize ) != 0 )
           {
-          for(d=0; d<m_NDims; d++)
-            {
-            float td;
-            char * const num = (char *)(&td);
-            for(k=0;k<sizeof(float);k++)
-              {
-              num[k] = _data[i+k];
-              }
-            MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-            i+=sizeof(float);
-            pnt->m_X[d] = (float)td;
-            }
+          pnt->m_Mark = true;
           }
-        else if( j == posR )
+        else
           {
-          float td;
-          char * num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_R = (float)td;
-          }
-        else if( j == posRn )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Ridgeness = td;
-          }
-        else if( j == posMn )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Medialness = (float)td;
-          }
-        else if( j == posBn )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Branchness = (float)td;
-          }
-        else if( j == posCv )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Curvature = (float)td;
-          }
-        else if( j == posLv )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Levelness = (float)td;
-          }
-        else if( j == posRo )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Roundness = (float)td;
-          }
-        else if( j == posIn )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Intensity = (float)td;
-          }
-        else if( j == posMk )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          if((float)td == 1.0)
-            {
-            pnt->m_Mark = true;
-            }
-          else
-            {
-            pnt->m_Mark = false;
-            }
-          }
-        else if( j == posV1x )
-          {
-          for(d = 0; d < m_NDims; d++)
-            {
-            float td;
-            char * const num = (char *)(&td);
-            for(k=0;k<sizeof(float);k++)
-              {
-              num[k] = _data[i+k];
-              }
-            MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-            i+=sizeof(float);
-            pnt->m_V1[d] = (float)td;
-            }
-          }
-        else if( j == posV2x )
-          {
-          for(d = 0; d < m_NDims; d++)
-            {
-            float td;
-            char * const num = (char *)(&td);
-            for(k=0;k<sizeof(float);k++)
-              {
-              num[k] = _data[i+k];
-              }
-            MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-            i+=sizeof(float);
-            pnt->m_V2[d] = (float)td;
-            }
-          }
-        else if( j == posTx )
-          {
-          for(d = 0; d < m_NDims; d++)
-            {
-            float td;
-            char * const num = (char *)(&td);
-            for(k=0;k<sizeof(float);k++)
-              {
-              num[k] = _data[i+k];
-              }
-            MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-            i+=sizeof(float);
-            pnt->m_T[d] = (float)td;
-            }
-          }
-        else if( j == posA1 )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Alpha1 = (float)td;
-          }
-        else if( j == posA2 )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Alpha2 = (float)td;
-          }
-        else if( j == posA3 )
-          {
-          float td;
-          char * const num = (char *)(&td);
-          for(k=0;k<sizeof(float);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-          i+=sizeof(float);
-          pnt->m_Alpha3 = (float)td;
-          }
-        else if( j == posRed )
-          {
-          for(d=0; d<4; d++)
-            {
-            float td;
-            char * const num = (char *)(&td);
-            for(k=0;k<sizeof(float);k++)
-              {
-              num[k] = _data[i+k];
-              }
-            MET_SwapByteIfSystemMSB(&td,MET_FLOAT);
-            i+=sizeof(float);
-            pnt->m_Color[d] = (float)td;
-            }
-          }
-        else if( j == posID )
-          {
-          int id;
-          char * const num = (char *)(&id);
-          for(k=0;k<sizeof(int);k++)
-            {
-            num[k] = _data[i+k];
-            }
-          MET_SwapByteIfSystemMSB(&id,MET_FLOAT);
-          i+=sizeof(int);
-          pnt->m_ID=id;
+          pnt->m_Mark = false;
           }
         }
+      if( posR != -1 )
+        {
+        pnt->m_R = M_GetFloatFromBinaryData( posR, _data, readSize );
+        }
+      if( posMn != -1 )
+        {
+        pnt->m_Medialness = M_GetFloatFromBinaryData( posMn, _data, readSize );
+        }
+      if( posRn != -1 )
+        {
+        pnt->m_Ridgeness = M_GetFloatFromBinaryData( posRn, _data, readSize );
+        }
+      if( posBn != -1 )
+        {
+        pnt->m_Branchness = M_GetFloatFromBinaryData( posBn, _data, readSize );
+        }
+      if( posCv != -1 )
+        {
+        pnt->m_Curvature = M_GetFloatFromBinaryData( posCv, _data, readSize );
+        }
+      if( posLv != -1 )
+        {
+        pnt->m_Levelness = M_GetFloatFromBinaryData( posLv, _data, readSize );
+        }
+      if( posRo != -1 )
+        {
+        pnt->m_Roundness = M_GetFloatFromBinaryData( posRo, _data, readSize );
+        }
+      if( posIn != -1 )
+        {
+        pnt->m_Intensity = M_GetFloatFromBinaryData( posIn, _data, readSize );
+        }
+      if( posTx != -1 )
+        {
+        pnt->m_T[0] = M_GetFloatFromBinaryData( posTx, _data, readSize );
+        }
+      if( posTy != -1 )
+        {
+        pnt->m_T[1] = M_GetFloatFromBinaryData( posTy, _data, readSize );
+        }
+      if( posTz != -1 )
+        {
+        pnt->m_T[2] = M_GetFloatFromBinaryData( posTz, _data, readSize );
+        }
+      if( posV1x != -1 )
+        {
+        pnt->m_V1[0] = M_GetFloatFromBinaryData( posV1x, _data, readSize );
+        }
+      if( posV1y != -1 )
+        {
+        pnt->m_V1[1] = M_GetFloatFromBinaryData( posV1y, _data, readSize );
+        }
+      if( posV1z != -1 )
+        {
+        pnt->m_V1[2] = M_GetFloatFromBinaryData( posV1z, _data, readSize );
+        }
+      if( posV2x != -1 )
+        {
+        pnt->m_V2[0] = M_GetFloatFromBinaryData( posV2x, _data, readSize );
+        }
+      if( posV2y != -1 )
+        {
+        pnt->m_V2[1] = M_GetFloatFromBinaryData( posV2y, _data, readSize );
+        }
+      if( posV2z != -1 )
+        {
+        pnt->m_V2[2] = M_GetFloatFromBinaryData( posV2z, _data, readSize );
+        }
+      if( posA1 != -1 )
+        {
+        pnt->m_Alpha1 = M_GetFloatFromBinaryData( posA1, _data, readSize );
+        }
+      if( posA2 != -1 )
+        {
+        pnt->m_Alpha2 = M_GetFloatFromBinaryData( posA2, _data, readSize );
+        }
+      if( posA3 != -1 )
+        {
+        pnt->m_Alpha3 = M_GetFloatFromBinaryData( posA3, _data, readSize );
+        }
+
+      std::vector<PositionType>::const_iterator itFields =
+        m_Positions.begin();
+      std::vector<PositionType>::const_iterator itUsed =
+        positionUsed.begin();
+      std::vector<PositionType>::const_iterator itFieldsEnd =
+        m_Positions.end();
+      while(itFields !=  itFieldsEnd)
+        {
+        if( !(*itUsed) )
+          {
+          pos = M_GetPosition((*itFields).first.c_str());
+          if( pos >= 0 )
+            {
+            float tf = M_GetFloatFromBinaryData( pos, _data, readSize );
+            pnt->AddField((*itFields).first.c_str(), tf);
+            }
+          }
+        ++itFields;
+        ++itUsed;
+        }
+
       m_PointList.push_back(pnt);
       }
     delete [] _data;
     }
   else
     {
-    for(j=0; j<(int)m_NPoints; j++)
+    for(j=0; j<m_NPoints; j++)
       {
       if(m_Event)
         {
         m_Event->SetCurrentIteration(j+1);
         }
 
-      TubePnt* pnt = new TubePnt(m_NDims);
-
-      for(int k=0; k<pntDim; k++)
+      for(unsigned int k=0; k<pntDim; k++)
         {
         *m_ReadStream >> v[k];
         m_ReadStream->get();
         }
 
-      for(int d=0; d<m_NDims; d++)
+      MetaPoint * pnt = new MetaPoint(m_NDims);
+
+      if( posX >= 0 )
         {
-        pnt->m_X[d] = v[posDim[d]];
+        pnt->m_X[0] = v[posX];
         }
-
-      pnt->m_R = v[posR];
-
-      if(posMn >= (int)0 && posMn < pntDim)
+      if( posId >= 0 )
         {
-        pnt->m_Medialness = v[posMn];
+        pnt->m_ID = v[posId];
         }
-
-      if(posRn >= (int)0 && posRn < pntDim)
+      if( posRed >= 0 )
+        {
+        pnt->m_Color[0] = v[posRed];
+        }
+      if( posGreen >= 0 )
+        {
+        pnt->m_Color[1] = v[posGreen];
+        }
+      if( posBlue >= 0 )
+        {
+        pnt->m_Color[2] = v[posBlue];
+        }
+      if( posAlpha >= 0 )
+        {
+        pnt->m_Color[3] = v[posAlpha];
+        }
+      if( posMark >= 0 )
+        {
+        pnt->m_Mark = (v[posMark]!=0)?true:false;
+        }
+      if( posR >= 0 )
+        {
+        pnt->m_R = v[posR];
+        }
+      if( posRn >= 0 )
         {
         pnt->m_Ridgeness = v[posRn];
         }
-
-      if(posBn >= (int)0 && posBn < pntDim)
+      if( posMn >= 0 )
+        {
+        pnt->m_Medialness = v[posMn];
+        }
+      if( posBn >= 0 )
         {
         pnt->m_Branchness = v[posBn];
         }
-
-      if(posCv >= (int)0 && posCv < pntDim)
+      if( posCv >= 0 )
         {
         pnt->m_Curvature = v[posCv];
         }
-
-      if(posLv >= (int)0 && posLv < pntDim)
+      if( posLv >= 0 )
         {
         pnt->m_Levelness = v[posLv];
         }
-
-      if(posRo >= (int)0 && posRo < pntDim)
+      if( posRo >= 0 )
         {
         pnt->m_Roundness = v[posRo];
         }
-
-      if(posIn >= (int)0 && posIn < pntDim)
+      if( posIn >= 0 )
         {
         pnt->m_Intensity = v[posIn];
         }
-
-      if(posMk >= 0 && posMk < pntDim)
-        {
-        pnt->m_Mark = (v[posMk] > 0) ? true:false;
-        }
-
-      if(posV1x>=0 && posV1x<pntDim)
-        {
-        pnt->m_V1[0] = v[posV1x];
-        if(posV1y >= 0 && posV1y<pntDim)
-          {
-          pnt->m_V1[1] = v[posV1y];
-          }
-        if(posV1z >= 0 && m_NDims>2 && posV1z<pntDim)
-          {
-          pnt->m_V1[2] = v[posV1z];
-          }
-        }
-      if(posV2x >= 0 && posV2x<pntDim)
-        {
-        pnt->m_V2[0] = v[posV2x];
-        if(posV2y >= 0 && posV2y<pntDim)
-          {
-          pnt->m_V2[1] = v[posV2y];
-          }
-        if(posV2z >= 0 && m_NDims>2 && posV2z<pntDim)
-          {
-          pnt->m_V2[2] = v[posV2z];
-          }
-        }
-      if(posTx >= 0 && posTx<pntDim)
+      if( posTx >= 0 )
         {
         pnt->m_T[0] = v[posTx];
-        if(posTy >= 0 && posTy<pntDim)
-          {
-          pnt->m_T[1] = v[posTy];
-          }
-        if(posTz >= 0 && m_NDims>2 && posTz<pntDim)
-          {
-          pnt->m_T[2] = v[posTz];
-          }
         }
-      if(posA1 >= 0 && posA1<pntDim)
+      if( posTy >= 0 )
+        {
+        pnt->m_T[1] = v[posTy];
+        }
+      if( posTz >= 0 )
+        {
+        pnt->m_T[2] = v[posTz];
+        }
+      if( posV1x >= 0 )
+        {
+        pnt->m_V1[0] = v[posV1x];
+        }
+      if( posV1y >= 0 )
+        {
+        pnt->m_V1[1] = v[posV1y];
+        }
+      if( posV1z >= 0 )
+        {
+        pnt->m_V1[2] = v[posV1z];
+        }
+      if( posV2x >= 0 )
+        {
+        pnt->m_V2[0] = v[posV2x];
+        }
+      if( posV2y >= 0 )
+        {
+        pnt->m_V2[1] = v[posV2y];
+        }
+      if( posV2z >= 0 )
+        {
+        pnt->m_V2[2] = v[posV2z];
+        }
+      if( posA1 >= 0 )
         {
         pnt->m_Alpha1 = v[posA1];
         }
-      if(posA2 >= 0 && posA2<pntDim)
+      if( posA2 >= 0 )
         {
         pnt->m_Alpha2 = v[posA2];
         }
-      if(posA3 >= 0 && posA3<pntDim)
+      if( posA3 >= 0 )
         {
         pnt->m_Alpha3 = v[posA3];
         }
 
-      if(posRed >= 0 && posRed < pntDim)
+      std::vector<PositionType>::const_iterator itFields =
+        m_Positions.begin();
+      std::vector<PositionType>::const_iterator itUsed =
+        positionUsed.begin();
+      std::vector<PositionType>::const_iterator itFieldsEnd =
+        m_Positions.end();
+      while(itFields !=  itFieldsEnd)
         {
-        pnt->m_Color[0] = v[posRed];
-        }
-
-      if(posGreen >= 0 && posGreen < pntDim)
-        {
-        pnt->m_Color[1] = v[posGreen];
-        }
-
-      if(posBlue >= 0 && posBlue < pntDim)
-        {
-        pnt->m_Color[2] = v[posBlue];
-        }
-
-      if(posAlpha >= 0 && posAlpha < pntDim)
-        {
-        pnt->m_Color[3] = v[posAlpha];
-        }
-
-      if(posID >= 0 && posID < pntDim)
-        {
-        pnt->m_ID = (int)v[posID];
+        if( !(*itUsed) )
+          {
+          std::string fldstr = (*itFields).first;
+          pnt->AddField( fldstr.c_str(),
+            v[this->M_GetPosition(fldstr.c_str())] );
+          }
+        ++itFields;
+        ++itUsed;
         }
 
       m_PointList.push_back(pnt);
       }
 
-
-    const std::string objectType = MET_ReadType(*m_ReadStream);
-    if(objectType.empty())
+    char c = ' ';
+    while( (c!='\n') && (!m_ReadStream->eof()))
       {
-      char c = ' ';
-      while( (c!='\n') && (m_ReadStream->good()))
-        {
-        c = static_cast<char>(m_ReadStream->get());// to avoid unrecognized characters
-        }
+      c = static_cast<char>(m_ReadStream->get());
+      // to avoid unrecognize charactere
       }
     }
 
@@ -1066,208 +1061,180 @@ M_Read()
     m_Event->StopReading();
     }
 
-  delete []posDim;
   return true;
-}
-
-MET_ValueEnumType MetaTube::
-ElementType() const
-{
-  return m_ElementType;
-}
-
-void MetaTube::
-ElementType(MET_ValueEnumType _elementType)
-{
-  m_ElementType = _elementType;
 }
 
 bool MetaTube::
 M_Write()
 {
 
+  // Convert point variables to ExtraFields for them to be written
+  // by base class.
+
+  TubePnt::FieldType newField;
+  PointListType::iterator it = m_PointList.begin();
+  PointListType::iterator itEnd = m_PointList.end();
+  int lastExtraField = (*it)->m_ExtraFields.size();
+  while( it != itEnd )
+    {
+    TubePnt * pnt = static_cast<TubePnt*>(*it);
+    if( pnt->m_R != -1 )
+      {
+      newField.first = "r";
+      newField.second = pnt->m_R;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Ridgeness != -1 )
+      {
+      newField.first = "rn";
+      newField.second = pnt->m_Ridgeness;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Medialness != -1 )
+      {
+      newField.first = "mn";
+      newField.second = pnt->m_Medialness;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Branchness != -1 )
+      {
+      newField.first = "bn";
+      newField.second = pnt->m_Branchness;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Curvature != -1 )
+      {
+      newField.first = "cv";
+      newField.second = pnt->m_Curvature;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Levelness != -1 )
+      {
+      newField.first = "lv";
+      newField.second = pnt->m_Levelness;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Roundness != -1 )
+      {
+      newField.first = "ro";
+      newField.second = pnt->m_Roundness;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Intensity != -1 )
+      {
+      newField.first = "in";
+      newField.second = pnt->m_Intensity;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_T[0] != -1 )
+      {
+      newField.first = "tx";
+      newField.second = pnt->m_T[0];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_T[1] != -1 )
+      {
+      newField.first = "ty";
+      newField.second = pnt->m_T[1];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( m_NDims == 3 && pnt->m_T[2] != -1 )
+      {
+      newField.first = "tz";
+      newField.second = pnt->m_T[2];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_V1[0] != -1 )
+      {
+      newField.first = "v1x";
+      newField.second = pnt->m_V1[0];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_V1[1] != -1 )
+      {
+      newField.first = "v1y";
+      newField.second = pnt->m_V1[1];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( m_NDims == 3 && pnt->m_V1[2] != -1 )
+      {
+      newField.first = "v1z";
+      newField.second = pnt->m_V1[2];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( m_NDims == 3 && pnt->m_V2[0] != -1 )
+      {
+      newField.first = "v2x";
+      newField.second = pnt->m_V2[0];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( m_NDims == 3 && pnt->m_V2[1] != -1 )
+      {
+      newField.first = "v2y";
+      newField.second = pnt->m_V2[1];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( m_NDims == 3 && pnt->m_V2[2] != -1 )
+      {
+      newField.first = "v2z";
+      newField.second = pnt->m_V2[2];
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Alpha1 != -1 )
+      {
+      newField.first = "a1";
+      newField.second = pnt->m_Alpha1;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( pnt->m_Alpha2 != -1 )
+      {
+      newField.first = "a2";
+      newField.second = pnt->m_Alpha2;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    if( m_NDims == 3 && pnt->m_Alpha3 != -1 )
+      {
+      newField.first = "a3";
+      newField.second = pnt->m_Alpha3;
+      pnt->m_ExtraFields.push_back(newField);
+      }
+    ++it;
+    }
+  
+  bool returnVal = true;
   if(!MetaObject::M_Write())
     {
     std::cout << "MetaTube: M_Read: Error parsing file"
                         << std::endl;
-    return false;
+    returnVal = false;
     }
 
-  /** Then copy all Tubes points */
-  if(m_BinaryData)
+  // Once the local vars have been written as ExtraFields, remove them
+  // from being ExtraFields.
+  if( lastExtraField == 0 )
     {
-    PointListType::const_iterator it = m_PointList.begin();
-    PointListType::const_iterator itEnd = m_PointList.end();
-    int elementSize;
-    MET_SizeOfType(m_ElementType, &elementSize);
-
-    // Allocates memory specifically needed to hold a TubePoint
-    char* data = new char[(m_NDims*(2+m_NDims)+14)*m_NPoints*elementSize];
-    int i=0;
-    int d;
-    while(it != itEnd)
+    it = m_PointList.begin();
+    itEnd = m_PointList.end();
+    while( it != itEnd )
       {
-      for(d = 0; d < m_NDims; d++)
-        {
-        float x = (*it)->m_X[d];
-        MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-        MET_DoubleToValue((double)x,m_ElementType,data,i++);
-        }
-
-      float x = (*it)->m_R;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Ridgeness;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Medialness;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Branchness;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Curvature;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Levelness;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Roundness;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Intensity;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Mark;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-
-      for(d = 0; d < m_NDims; d++)
-        {
-        x = (*it)->m_V1[d];
-        MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-        MET_DoubleToValue((double)x,m_ElementType,data,i++);
-        }
-
-      if(m_NDims==3)
-        {
-        for(d = 0; d < m_NDims; d++)
-          {
-          x = (*it)->m_V2[d];
-          MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-          MET_DoubleToValue((double)x,m_ElementType,data,i++);
-          }
-        }
-
-      for(d = 0; d < m_NDims; d++)
-        {
-        x = (*it)->m_T[d];
-        MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-        MET_DoubleToValue((double)x,m_ElementType,data,i++);
-        }
-
-      x = (*it)->m_Alpha1;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-      x = (*it)->m_Alpha2;
-      MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-      MET_DoubleToValue((double)x,m_ElementType,data,i++);
-
-      if(m_NDims>=3)
-        {
-        x = (*it)->m_Alpha3;
-        MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-        MET_DoubleToValue((double)x,m_ElementType,data,i++);
-        }
-
-      for(d=0; d<4; d++)
-        {
-        x = (*it)->m_Color[d];
-        MET_SwapByteIfSystemMSB(&x,MET_FLOAT);
-        MET_DoubleToValue((double)x,m_ElementType,data,i++);
-        }
-
-      int id = (*it)->m_ID;
-      MET_SwapByteIfSystemMSB(&id,MET_INT);
-      MET_DoubleToValue((double)id,m_ElementType,data,i++);
-
+      (*it)->m_ExtraFields.clear();
       ++it;
       }
-
-    m_WriteStream->write((char *)data,
-                         (m_NDims*(2+m_NDims)+10)*m_NPoints*elementSize);
-    m_WriteStream->write("\n",1);
-    delete [] data;
     }
   else
     {
-    PointListType::const_iterator it = m_PointList.begin();
-    PointListType::const_iterator itEnd = m_PointList.end();
-
-    int d;
-    while(it != itEnd)
+    it = m_PointList.begin();
+    itEnd = m_PointList.end();
+    while( it != itEnd )
       {
-      for(d = 0; d < m_NDims; d++)
-        {
-        *m_WriteStream << (*it)->m_X[d] << " ";
-        }
-
-      *m_WriteStream << (*it)->m_R << " ";
-      *m_WriteStream << (*it)->m_Ridgeness << " ";
-      *m_WriteStream << (*it)->m_Medialness << " ";
-      *m_WriteStream << (*it)->m_Branchness << " ";
-      *m_WriteStream << (*it)->m_Curvature << " ";
-      *m_WriteStream << (*it)->m_Levelness << " ";
-      *m_WriteStream << (*it)->m_Roundness << " ";
-      *m_WriteStream << (*it)->m_Intensity << " ";
-      if((*it)->m_Mark)
-        {
-        *m_WriteStream << 1 << " ";
-        }
-      else
-        {
-        *m_WriteStream << 0 << " ";
-        }
-
-      for(d = 0; d < m_NDims; d++)
-        {
-        *m_WriteStream << (*it)->m_V1[d] << " ";
-        }
-
-      if(m_NDims>=3)
-        {
-        for(d = 0; d < m_NDims; d++)
-          {
-          *m_WriteStream << (*it)->m_V2[d] << " ";
-          }
-        }
-
-      for(d = 0; d < m_NDims; d++)
-        {
-        *m_WriteStream << (*it)->m_T[d] << " ";
-        }
-
-      *m_WriteStream << (*it)->m_Alpha1 << " ";
-      *m_WriteStream << (*it)->m_Alpha2 << " ";
-
-      if(m_NDims>=3)
-        {
-        *m_WriteStream << (*it)->m_Alpha3 << " ";
-        }
-
-      for(d=0;d<4;d++)
-        {
-        *m_WriteStream << (*it)->m_Color[d] << " ";
-        }
-
-      *m_WriteStream << (*it)->m_ID << " ";
-
-      *m_WriteStream << std::endl;
+      (*it)->m_ExtraFields.erase(
+        (*it)->m_ExtraFields.begin()+lastExtraField,
+        (*it)->m_ExtraFields.end() );
       ++it;
       }
     }
-  return true;
+
+  return returnVal;
 
 }
 

--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -16,6 +16,7 @@
 
 #include "metaUtils.h"
 #include "metaObject.h"
+#include "metaPointObject.h"
 
 #ifdef _MSC_VER
 #pragma warning ( disable: 4251 )
@@ -42,31 +43,49 @@ class METAIO_EXPORT TubePnt
 {
 public:
 
+  typedef std::pair<std::string,float>  FieldType;
+  typedef std::vector<FieldType>        FieldListType;
+
   TubePnt(int dim);
+  TubePnt(const TubePnt * _tubePnt);
   ~TubePnt();
 
-  unsigned int m_Dim;
+  unsigned int m_NDims;
+  int    m_ID;
+  float* m_X;
+  float  m_Color[4];
+  bool   m_Mark;
+  float  m_R;
+  float  m_Ridgeness;
+  float  m_Medialness;
+  float  m_Branchness;
+  float  m_Curvature;
+  float  m_Levelness;
+  float  m_Roundness;
+  float  m_Intensity;
+  float* m_T;
   float* m_V1;
   float* m_V2;
-  float* m_X;
-  float* m_T;
-  float m_Alpha1;
-  float m_Alpha2;
-  float m_Alpha3;
-  float m_R;
-  float m_Medialness;
-  float m_Ridgeness;
-  float m_Branchness;
-  float m_Curvature;
-  float m_Levelness;
-  float m_Roundness;
-  float m_Intensity;
-  bool  m_Mark;
-  float m_Color[4];
-  int   m_ID;
+  float  m_Alpha1;
+  float  m_Alpha2;
+  float  m_Alpha3;
+
+  FieldListType m_ExtraFields; 
+
+  virtual void CopyInfo( const TubePnt * _tubePnt );
+
+  const FieldListType & GetExtraFields() const;
+
+  int GetNumberOfExtraFields( void ) const;
+  void SetNumberOfExtraFields( int size );
+
+  void SetField(int indx, const char* name, float value);
+  void SetField(const char* name, float value);
+  void AddField(const char* name, float value);
+  int GetFieldIndex(const char* name) const;
+  float GetField(int indx) const;
+  float GetField(const char* name) const;
 };
-
-
 
 
 class METAIO_EXPORT MetaTube : public MetaObject
@@ -79,7 +98,9 @@ class METAIO_EXPORT MetaTube : public MetaObject
   ////
   public:
 
-   typedef std::list<TubePnt*> PointListType;
+    typedef TubePnt                             PointType;
+    typedef std::list<PointType*>               PointListType;
+
     ////
     //
     // Constructors & Destructor
@@ -97,46 +118,50 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     void PrintInfo(void) const override;
 
-    void CopyInfo(const MetaObject * _object) override;
+    void CopyInfo(const MetaTube * _object);
 
-    //    NPoints(...)
-    //       Required Field
-    //       Number of points which compose the Tube
-    void  NPoints(int npnt);
-    int   NPoints(void) const;
+    void Clear(void);
+
+    MET_ValueEnumType ElementType(void) const;
+    void              ElementType(MET_ValueEnumType _elementType);
 
     //    PointDim(...)
     //       Required Field
     //       Definition of points
-    void        PointDim(const char* pointDim);
     const char* PointDim(void) const;
+
+    //    NPoints(...)
+    //       Required Field
+    //       Number of points which compose the MetaPointObject
+    void  NPoints(int npnt);
+    int   NPoints(void) const;
+
+    PointListType &       GetPoints(void) {return m_PointList;}
+    const PointListType & GetPoints(void) const {return m_PointList;}
 
     //    Root(...)
     //       Optional Field
     //       Set if this Tube is a root
-    void  Root(bool root);
-    bool  Root(void) const;
+    void  Root(bool root)
+      { m_Root = root; };
+    bool  Root(void) const
+      { return m_Root; };
 
     //    Artery(...)
     //       Optional Field
     //       Set if this Tube is a root
-    void  Artery(bool artery);
-    bool  Artery(void) const;
-
+    void  Artery(bool artery)
+      { m_Artery = artery; };
+    bool  Artery(void) const
+      { return m_Artery; };
 
     //    ParentPoint(...)
     //       Optional Field
     //       Set the point number of the parent Tube where the branch occurs
-    void  ParentPoint(int parentpoint);
-    int   ParentPoint(void) const;
-
-    void  Clear(void) override;
-
-    PointListType &  GetPoints(void) {return m_PointList;}
-    const PointListType &  GetPoints(void) const {return m_PointList;}
-
-    MET_ValueEnumType ElementType(void) const;
-    void  ElementType(MET_ValueEnumType _elementType);
+    void  ParentPoint(int parentPoint )
+      { m_ParentPoint = parentPoint; };
+    int   ParentPoint(void) const
+      { return m_ParentPoint; };
 
   ////
   //
@@ -145,7 +170,12 @@ class METAIO_EXPORT MetaTube : public MetaObject
   ////
   protected:
 
-    bool  m_ElementByteOrderMSB;
+    typedef std::pair<std::string,unsigned int> PositionType;
+
+    int   M_GetPosition(const char*, std::vector<bool> & used) const;
+
+    float M_GetFloatFromBinaryData( int post, char * _data,
+      int readSize ) const;
 
     void  M_Destroy(void) override;
 
@@ -157,18 +187,22 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     bool  M_Write(void) override;
 
-    int   m_ParentPoint;  // "ParentPoint = "     -1
+    int                        m_NPoints;
 
-    bool  m_Root;         // "Root = "            false
+    std::string                m_PointDim;
 
-    bool  m_Artery;         // "Artery = "            true
+    PointListType              m_PointList;
 
-    int   m_NPoints;      // "NPoints = "         0
+    MET_ValueEnumType          m_ElementType;
 
-    char m_PointDim[255]; // "PointDim = "       "x y z r"
+    int                        m_ParentPoint;
 
-    PointListType m_PointList;
-    MET_ValueEnumType m_ElementType;
+    bool                       m_Root;
+
+    bool                       m_Artery;
+
+    std::vector<PositionType>  m_Positions;
+
 };
 
 #if (METAIO_USE_NAMESPACE)

--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -16,7 +16,6 @@
 
 #include "metaUtils.h"
 #include "metaObject.h"
-#include "metaPointObject.h"
 
 #ifdef _MSC_VER
 #pragma warning ( disable: 4251 )
@@ -76,7 +75,7 @@ public:
 
   const FieldListType & GetExtraFields() const;
 
-  int GetNumberOfExtraFields( void ) const;
+  size_t GetNumberOfExtraFields( void ) const;
   void SetNumberOfExtraFields( int size );
 
   void SetField(int indx, const char* name, float value);
@@ -129,6 +128,7 @@ class METAIO_EXPORT MetaTube : public MetaObject
     //       Required Field
     //       Definition of points
     const char* PointDim(void) const;
+    void PointDim(const char * pntDim);
 
     //    NPoints(...)
     //       Required Field
@@ -174,8 +174,10 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     int   M_GetPosition(const char*, std::vector<bool> & used) const;
 
-    float M_GetFloatFromBinaryData( int post, char * _data,
-      int readSize ) const;
+    float M_GetFloatFromBinaryData( int post, const char * _data,
+      size_t readSize ) const;
+
+    void  M_SetFloatIntoBinaryData( float val, char * _data, int post ) const;
 
     void  M_Destroy(void) override;
 

--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -174,7 +174,7 @@ class METAIO_EXPORT MetaTube : public MetaObject
 
     int   M_GetPosition(const char*, std::vector<bool> & used) const;
 
-    float M_GetFloatFromBinaryData( int post, const char * _data,
+    float M_GetFloatFromBinaryData( size_t post, const char * _data,
       size_t readSize ) const;
 
     void  M_SetFloatIntoBinaryData( float val, char * _data, int post ) const;


### PR DESCRIPTION
Extends MetaTubePoint to allow for arbitrary fields to be added to every point.   This allows every point along a tube to have a vector/payload of additional information.

This change required fixing MetaTube to allow arbitrary ordering of information for its points. 