### PR TITLE
ENH: MetaIO support reading strings of >= 500 chars (up to 32767 chars)

### DIFF
--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -1227,7 +1227,7 @@ bool MET_Read(std::istream &fp,
         MET_FieldRecordType * mF = new MET_FieldRecordType;
         MET_InitReadField(mF, s, MET_STRING, false);
         MET_ASCII_CHAR_TYPE * str = (MET_ASCII_CHAR_TYPE *)(mF->value);
-        fp.getline( str, 500 );
+        fp.getline( str, sizeof(mF->value) );
         MET_StringStripEnd(str);
         mF->length = static_cast<int>( strlen( str ) );
         newFields->push_back(mF);


### PR DESCRIPTION
MetaIO `MET_Read` did read at most 499 chars from a MET_STRING field,
while `MET_FieldRecordType::value` allows storing up to 32767 chars,
as it is an array of 4096 (`MET_MAX_NUMBER_OF_FIELD_VALUES`) 64-bit
`double` elements. (Only one extra byte is needed for a terminating zero
character.)

This commit allows reading up to 32767 chars into a MET_STRING field.

Note that `MET_Write` already supports writing such large string values.