### PR TITLE
COMP: Fix hidden overloaded-virtual warning

### DIFF
--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -119,6 +119,8 @@ public:
   void
   PrintInfo(void) const override;
 
+  using MetaObject::CopyInfo;
+
   void
   CopyInfo(const MetaTube * _object);
 


### PR DESCRIPTION
Building CXX object Modules/IO/SpatialObjects/test/CMakeFiles/ITKIOSpatialObjectsTestDriver.dir/itkReadWriteSpatialObjectTest.cxx.o
In file included from ITK/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaScene.h:18:0,
                 from ITK/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.h:24,
                 from ITK/Modules/IO/SpatialObjects/include/itkSpatialObjectWriter.h:21,
                 from ITK/Modules/IO/SpatialObjects/test/itkReadWriteSpatialObjectTest.cxx:19:
ITK/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.h:125:3:
warning: ‘virtual void MetaObject::CopyInfo(const MetaObject*)’ was hidden [-Woverloaded-virtual]
   CopyInfo(const MetaObject * _object);
   ^~~~~~~~