### PR TITLE
BUG: Fix MetaImage::m_CompressionTable leak

### DIFF
--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -271,7 +271,7 @@ MetaImage::MetaImage(int               _x,
 //
 MetaImage::~MetaImage()
 {
-MetaObject::M_Destroy();
+  MetaImage::M_ResetValues();
 }
 
 //


### PR DESCRIPTION
The m_CompressionTable ivar was detected by valgrind as not being
deleted. In 632a827, the MetaImage::M_Delete was renamed to
M_ResetValues; this is the method which handles resource
deleting.

Closes #100.