### PR TITLE
Fixed various clang warnings

### DIFF
--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -755,9 +755,8 @@ MetaObject::DistanceUnits(MET_DistanceUnitsEnumType _distanceUnits)
 void
 MetaObject::DistanceUnits(const char * _distanceUnits)
 {
-  int  i;
   bool found = false;
-  for (i = 0; i < MET_NUM_DISTANCE_UNITS_TYPES; i++)
+  for (size_t i = 0; i < MET_NUM_DISTANCE_UNITS_TYPES; i++)
   {
     if (!strcmp(_distanceUnits, MET_DistanceUnitsTypeName[i]))
     {
@@ -800,7 +799,7 @@ void
 MetaObject::AnatomicalOrientation(const char * _ao)
 {
   int i;
-  int j;
+  size_t j;
   for (i = 0; i < m_NDims; i++)
   {
     for (j = 0; j < MET_NUM_ORIENTATION_TYPES; j++)
@@ -837,8 +836,7 @@ MetaObject::AnatomicalOrientation(int _dim, MET_OrientationEnumType _ao)
 void
 MetaObject::AnatomicalOrientation(int _dim, char _ao)
 {
-  int j;
-  for (j = 0; j < MET_NUM_ORIENTATION_TYPES; j++)
+  for (size_t j = 0; j < MET_NUM_ORIENTATION_TYPES; j++)
   {
     if (_ao == MET_OrientationTypeName[j][0])
     {

--- a/src/metaTube.cxx
+++ b/src/metaTube.cxx
@@ -206,7 +206,7 @@ TubePnt::GetFieldIndex(const char * name) const
 float
 TubePnt::GetField(int indx) const
 {
-  if (indx >= 0 && indx < m_ExtraFields.size())
+  if (indx >= 0 && static_cast<size_t>(indx) < m_ExtraFields.size())
   {
     return m_ExtraFields[indx].second;
   }
@@ -534,7 +534,7 @@ MetaTube::M_SetFloatIntoBinaryData(float val, char * _data, int i) const
 float
 MetaTube::M_GetFloatFromBinaryData(size_t pos, const char * _data, size_t readSize)
 {
-  if (pos >= 0 && pos < readSize)
+  if (pos < readSize)
   {
     float        tf;
     char * const num = reinterpret_cast<char *>(&tf);

--- a/src/metaTube.h
+++ b/src/metaTube.h
@@ -168,12 +168,12 @@ public:
   Root(bool root)
   {
     m_Root = root;
-  };
+  }
   bool
   Root() const
   {
     return m_Root;
-  };
+  }
 
   //    Artery(...)
   //       Optional Field
@@ -182,12 +182,12 @@ public:
   Artery(bool artery)
   {
     m_Artery = artery;
-  };
+  }
   bool
   Artery() const
   {
     return m_Artery;
-  };
+  }
 
   //    ParentPoint(...)
   //       Optional Field
@@ -196,12 +196,12 @@ public:
   ParentPoint(int parentPoint)
   {
     m_ParentPoint = parentPoint;
-  };
+  }
   int
   ParentPoint() const
   {
     return m_ParentPoint;
-  };
+  }
 
   // PROTECTED
 protected:

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -220,8 +220,7 @@ MET_ReadSubType(std::istream & _fp)
 bool
 MET_StringToType(const char * _s, MET_ValueEnumType * _vType)
 {
-  int i;
-  for (i = 0; i < MET_NUM_VALUE_TYPES; i++)
+  for (size_t i = 0; i < MET_NUM_VALUE_TYPES; i++)
   {
     if (!strcmp(_s, MET_ValueTypeName[i]))
     {
@@ -1660,9 +1659,7 @@ MET_WriteFieldToFile(std::ostream & _fp, const char * _fieldName, MET_ValueEnumT
 bool
 MET_StringToInterpolationType(const char * _str, MET_InterpolationEnumType * _type)
 {
-  int i;
-
-  for (i = 0; i < MET_NUM_INTERPOLATION_TYPES; i++)
+  for (size_t i = 0; i < MET_NUM_INTERPOLATION_TYPES; i++)
   {
     if (!strcmp(MET_InterpolationTypeName[i], _str))
     {


### PR DESCRIPTION
Specifically: -Wtautological-unsigned-zero-compare, -Wextra-semi, and -Wsign-compare