### PR TITLE
COMP: Fix VS2019 /Wall warning: there is no warning number '4284'

### DIFF
--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -40,7 +40,6 @@
 #    pragma warning(disable : 4251)
 #    pragma warning(disable : 4511)
 #    pragma warning(disable : 4512)
-#    pragma warning(disable : 4284)
 #    pragma warning(disable : 4702)
 #    pragma warning(disable : 4786)
 #    pragma warning(disable : 4996)


### PR DESCRIPTION
Fixed the following warning from Visual C++/Visual Studio 2019 (which
occurs when all warnings are enabled, by "/Wall"):

> metaUtils.h(43,13): warning C4619: #pragma warning: there is no warning number '4284'

VS2015, VS2017, and VS2019 no longer produce warning C4284.