### PR TITLE
Fix >2GB compressed files read problem

### DIFF
--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -1487,7 +1487,7 @@ MetaObject::M_Read()
   mF = MET_GetFieldRecord("CompressedDataSize", &m_Fields);
   if (mF && mF->defined)
   {
-    m_CompressedDataSize = static_cast<long>(mF->value[0]);
+    m_CompressedDataSize = static_cast<std::streamoff>(mF->value[0]);
   }
 
   mF = MET_GetFieldRecord("BinaryData", &m_Fields);


### PR DESCRIPTION
Cast value for CompressedDataSize to its actual type, std::streamoff