### PR TITLE
Make ElementDataFileName always use UTF-8 encoding

### DIFF
--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -334,7 +334,7 @@ MetaImage::PrintInfo() const
 
   std::cout << "ElementData = " << ((m_ElementData == nullptr) ? "NULL" : "Valid") << std::endl;
 
-  std::cout << "ElementDataFileName = " << m_ElementDataFileName << std::endl;
+  std::cout << "ElementDataFileName = " << fromUtf8ToLocalEncoding(m_ElementDataFileName) << std::endl;
 }
 
 void
@@ -859,7 +859,7 @@ MetaImage::ElementDataFileName() const
 void
 MetaImage::ElementDataFileName(const char * _elementDataFileName)
 {
-  m_ElementDataFileName = _elementDataFileName;
+  m_ElementDataFileName = fromLocalToUtf8Encoding(_elementDataFileName);
 }
 
 void *
@@ -1172,7 +1172,6 @@ MetaImage::CanReadStream(std::ifstream * _stream)
   return false;
 }
 
-
 bool
 MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, void * _buffer)
 {
@@ -1372,11 +1371,11 @@ MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, v
     {
       if (usePath && !FileIsFullPath(m_ElementDataFileName.c_str()))
       {
-        fName = pathName + m_ElementDataFileName;
+        fName = pathName + fromUtf8ToLocalEncoding(m_ElementDataFileName);
       }
       else
       {
-        fName = m_ElementDataFileName;
+        fName = fromUtf8ToLocalEncoding(m_ElementDataFileName);
       }
 
       auto * readStreamTemp = new std::ifstream;
@@ -1485,7 +1484,7 @@ MetaImage::Write(const char * _headName,
     if (pathName == elementPathName)
     {
       elementPathName = m_ElementDataFileName.substr(pathName.length());
-      m_ElementDataFileName = elementPathName;
+      m_ElementDataFileName = fromLocalToUtf8Encoding(elementPathName);
     }
   }
 

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -334,7 +334,7 @@ MetaImage::PrintInfo() const
 
   std::cout << "ElementData = " << ((m_ElementData == nullptr) ? "NULL" : "Valid") << std::endl;
 
-  std::cout << "ElementDataFileName = " << fromUtf8ToLocalEncoding(m_ElementDataFileName) << std::endl;
+  std::cout << "ElementDataFileName = " << MET_FromUtf8ToLocalEncoding(m_ElementDataFileName) << std::endl;
 }
 
 void
@@ -859,7 +859,7 @@ MetaImage::ElementDataFileName() const
 void
 MetaImage::ElementDataFileName(const char * _elementDataFileName)
 {
-  m_ElementDataFileName = fromLocalToUtf8Encoding(_elementDataFileName);
+  m_ElementDataFileName = MET_FromLocalToUtf8Encoding(_elementDataFileName);
 }
 
 void *
@@ -1371,11 +1371,11 @@ MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, v
     {
       if (usePath && !FileIsFullPath(m_ElementDataFileName.c_str()))
       {
-        fName = pathName + fromUtf8ToLocalEncoding(m_ElementDataFileName);
+        fName = pathName + MET_FromUtf8ToLocalEncoding(m_ElementDataFileName);
       }
       else
       {
-        fName = fromUtf8ToLocalEncoding(m_ElementDataFileName);
+        fName = MET_FromUtf8ToLocalEncoding(m_ElementDataFileName);
       }
 
       auto * readStreamTemp = new std::ifstream;
@@ -1484,7 +1484,7 @@ MetaImage::Write(const char * _headName,
     if (pathName == elementPathName)
     {
       elementPathName = m_ElementDataFileName.substr(pathName.length());
-      m_ElementDataFileName = fromLocalToUtf8Encoding(elementPathName);
+      m_ElementDataFileName = MET_FromLocalToUtf8Encoding(elementPathName);
     }
   }
 

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -1844,26 +1844,26 @@ ToNarrow(const std::wstring & str, int encoding)
 } // namespace
 
 std::string
-fromUtf8ToLocalEncoding(const std::string & str)
+MET_FromUtf8ToLocalEncoding(const std::string & str)
 {
   return ToNarrow(ToWide(str, CP_UTF8), CP_ACP);
 }
 
 std::string
-fromLocalToUtf8Encoding(const std::string & str)
+MET_FromLocalToUtf8Encoding(const std::string & str)
 {
   return ToNarrow(ToWide(str, CP_ACP), CP_UTF8);
 }
 #else
 // other operating systems use UTF-8 encoding by default (?)
 std::string
-fromUtf8ToLocalEncoding(const std::string & str)
+MET_FromUtf8ToLocalEncoding(const std::string & str)
 {
   return str;
 }
 
 std::string
-fromLocalToUtf8Encoding(const std::string & str)
+MET_FromLocalToUtf8Encoding(const std::string & str)
 {
   return str;
 }

--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -437,11 +437,11 @@ MET_ReadSubType(std::istream & _fp);
 
 METAIO_EXPORT
 std::string
-fromUtf8ToLocalEncoding(const std::string& str);
+MET_FromUtf8ToLocalEncoding(const std::string& str);
 
 METAIO_EXPORT
 std::string
-fromLocalToUtf8Encoding(const std::string& str);
+MET_FromLocalToUtf8Encoding(const std::string& str);
 
 #  if (METAIO_USE_NAMESPACE)
 };

--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -435,6 +435,14 @@ METAIO_EXPORT
 char *
 MET_ReadSubType(std::istream & _fp);
 
+METAIO_EXPORT
+std::string
+fromUtf8ToLocalEncoding(const std::string& str);
+
+METAIO_EXPORT
+std::string
+fromLocalToUtf8Encoding(const std::string& str);
+
 #  if (METAIO_USE_NAMESPACE)
 };
 #  endif


### PR DESCRIPTION
Attempt to fix https://github.com/Kitware/MetaIO/issues/68.

Limitations:
- Only handles the `ElementDataFileName` field in datasets of type metaImage; I have seen the same field being used in e.g. metaArray and metaFEMObject as well, but I cannot test these at the moment; as for other MET_STRING fields, I have no idea if any might need such handling as well, and if so what consequences this might have, therefore I didn't touch them.
- Not sure if all possible cases are handled correctly; I only have limited ability to test, and I don't know all possibilites of how the code is used from VTK/ITK. There is for example a logic of determining the ElementDataFileName from the FileName in the ::Write method, which I don't fully get; or rather I don't get why it intermittently sets the ElementDataFileName to the full data file path, and only later cuts away the path again; because this makes it a bit tricky to handle if the path itself also contains special characters - one should not encode the full path immediately in utf-8, since later, the path is extracted again from the ElementDataFileName, and a comparisons to the non-utf-8 encoded version of the file path is done....
- The file name itself still has to be specified in local encoding (on Windows).
-  I considered adding a test case to testMeta3Image.cxx, but couldn't figure out how to set the file name properly, as source files are by default stored in utf-8 (but we would need to provide an ANSI filename on Windows)

Maybe a solution using vtksys iostreams (https://gitlab.kitware.com/paraview/paraview/-/merge_requests/3850) would be preferrable? Though this would probably break backwards-compatibility, since all file names would then be expected to be in UTF-8 format I guess?