### PR TITLE
BUG: Do not allow user fields with the same names as keywords.

### DIFF
--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -84,6 +84,16 @@ namespace METAIO_NAMESPACE
 // 1 Gigabyte is the maximum chunk to read/write in on function call
 static const std::streamoff MaxIOChunk = 1024 * 1024 * 1024;
 
+std::set<std::string> MetaImage::m_ImageReservedKeywords = {
+    "Modality",
+    "DimSize",
+    "SequenceID",
+    "ElementSizeValid",
+    "ElementSize",
+    "ElementType",
+    "ElementDataFileName",
+ };
+
 //
 // MetaImage Constructors
 //
@@ -91,6 +101,7 @@ MetaImage::MetaImage()
 {
   META_DEBUG_PRINT( "MetaImage()" );
 
+  AddReservedKeywords(m_ImageReservedKeywords);
   m_CompressionTable = new MET_CompressionTableType;
   m_CompressionTable->compressedStream = nullptr;
   m_CompressionTable->buffer = nullptr;
@@ -102,6 +113,7 @@ MetaImage::MetaImage(const char * _headerName)
 {
   META_DEBUG_PRINT( "MetaImage()" );
 
+  AddReservedKeywords(m_ImageReservedKeywords);
   m_CompressionTable = new MET_CompressionTableType;
   m_CompressionTable->compressedStream = nullptr;
   m_CompressionTable->buffer = nullptr;
@@ -115,6 +127,7 @@ MetaImage::MetaImage(MetaImage * _im)
 {
   META_DEBUG_PRINT( "MetaImage()" );
 
+  AddReservedKeywords(m_ImageReservedKeywords);
   m_CompressionTable = new MET_CompressionTableType;
   m_CompressionTable->compressedStream = nullptr;
   m_CompressionTable->buffer = nullptr;
@@ -164,6 +177,7 @@ MetaImage::MetaImage(int               _nDims,
                      int               _elementNumberOfChannels,
                      void *            _elementData)
 {
+  AddReservedKeywords(m_ImageReservedKeywords);
   // Only consider at most 10 element of spacing:
   // See MetaObject::InitializeEssential(_nDims)
   double tmpElementSpacing[10];
@@ -183,6 +197,7 @@ MetaImage::MetaImage(int               _nDims,
                      int               _elementNumberOfChannels,
                      void *            _elementData)
 {
+  AddReservedKeywords(m_ImageReservedKeywords);
   InitHelper(_nDims, _dimSize, _elementSpacing, _elementType, _elementNumberOfChannels, _elementData);
 }
 
@@ -197,6 +212,7 @@ MetaImage::MetaImage(int               _x,
 {
   META_DEBUG_PRINT( "MetaImage()" );
 
+  AddReservedKeywords(m_ImageReservedKeywords);
   m_CompressionTable = new MET_CompressionTableType;
   m_CompressionTable->compressedStream = nullptr;
   m_CompressionTable->buffer = nullptr;
@@ -233,6 +249,7 @@ MetaImage::MetaImage(int               _x,
 {
   META_DEBUG_PRINT( "MetaImage()" );
 
+  AddReservedKeywords(m_ImageReservedKeywords);
   m_CompressionTable = new MET_CompressionTableType;
   m_CompressionTable->compressedStream = nullptr;
   m_CompressionTable->buffer = nullptr;

--- a/src/metaImage.h
+++ b/src/metaImage.h
@@ -351,6 +351,8 @@ public:
 
   // PROTECTED
 protected:
+  static std::set<std::string> m_ImageReservedKeywords;
+
   MET_ImageModalityEnumType m_Modality;
 
 

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -87,6 +87,20 @@ MetaObject::M_Destroy();
 }
 
 
+std::set<std::string>
+MetaObject::GetReservedKeywords() const
+{
+  return m_ReservedKeywords;
+}
+
+
+void
+MetaObject::AddReservedKeywords(std::set<std::string> additionalKeywords)
+{
+  m_ReservedKeywords.insert(additionalKeywords.begin(), additionalKeywords.end());
+}
+
+
 // Clear Fields only, if the pointer is in the UserField list it is not deleted.
 void
 MetaObject::ClearFields()

--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -18,6 +18,7 @@
 #  include "metaEvent.h"
 
 #  include <string>
+#include <set>
 
 #  ifdef _MSC_VER
 #    pragma warning(disable : 4251)
@@ -33,6 +34,26 @@ class METAIO_EXPORT MetaObject
 {
   // PROTECTED
 protected:
+  std::set<std::string> m_ReservedKeywords = {
+    "ObjectType",
+    "ObjectSubType",
+    "NDims",
+    "Offset",
+    "Position",
+    "Origin",
+    "TransformMatrix",
+    "CenterOfRotation",
+    "AnatomicalOrientation",
+    "DistanceUnits",
+    "ElementSpacing",
+    "Color",
+    "AcquisitionDate",
+    "BinaryData",
+    "BinaryDataByteOrderMSB",
+    "CompressedData",
+    "CompressionLevel"
+  };
+
   typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
   std::ifstream * m_ReadStream;
@@ -85,6 +106,9 @@ protected:
 
   static void M_Destroy();
 
+  void
+  AddReservedKeywords(std::set<std::string> additionalKeywords);
+
   virtual void
   M_SetupReadFields();
 
@@ -114,6 +138,9 @@ public:
   explicit MetaObject(unsigned int dim);
 
   virtual ~MetaObject();
+
+  std::set<std::string>
+  GetReservedKeywords() const;
 
   void
   FileName(const char * _fileName);
@@ -382,6 +409,12 @@ public:
                bool              _required = true,
                int               _dependsOn = -1)
   {
+    // if given field name is one of the reserved keywords,
+    // don't add it
+    if(m_ReservedKeywords.find(std::string(_fieldName)) != m_ReservedKeywords.end())
+    {
+    return false;
+    }
     // don't add the same field twice. In the unlikely event
     // a field of the same name gets added more than once,
     // over-write the existing FieldRecord

--- a/src/tests/testMeta3Image.cxx
+++ b/src/tests/testMeta3Image.cxx
@@ -22,6 +22,13 @@ main(int, char *[])
     }
   }
 
+  // user field cannot use reserved keywords
+  char m[] = { 'C', 'T', '\0' };
+  if(tIm.AddUserField("Modality", MET_STRING, 3, m))
+  {
+    return EXIT_FAILURE;
+  }
+
   tIm.Write("test.mha");
   tIm.PrintInfo();
 


### PR DESCRIPTION
The MetaObject framework uses multiple keywords. Additionally it allows the user to specify user fields (metadata). When the user fields use the same names as the keywords, writing succeeds but the resulting files are not valid. This commit adds a check so that the user cannot name a user supplied field using a reserved keyword.

resolves #54