### PR TITLE
ENH: Restored use of METAIO_STREAM with ifstream/ofstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required( VERSION 3.10.2 )
 
-set( METAIO_FOR_ITK 1 )
-set( METAIO_NAMESPACE "ITKMetaIO" )
+set( METAIO_FOR_ITK 0 )
+set( METAIO_FOR_VTK 0 )
+set( METAIO_NAMESPACE "MetaIO" )
 
 ## Define language standard configurations requiring at least C++11 standard.
 if(CMAKE_CXX_STANDARD EQUAL "98" )

--- a/metaIOConfig.h
+++ b/metaIOConfig.h
@@ -16,4 +16,4 @@
 
 #undef METAIO_FOR_VTK
 
-#define METAIO_FOR_ITK 1
+#undef METAIO_FOR_ITK

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,15 +122,14 @@ else ()
     ${sources}
     ${headers}
   )
+  if (METAIO_FOR_ITK)
+    target_link_libraries(${METAIO_TARGET} PUBLIC
+      itksys
+    )
+  endif (METAIO_FOR_ITK)
 endif ()
 
 include_regular_expression("^.*$")
-
-# Need nsl to resolve gethostbyname on SunOS-5.8
-# and socket also
-if(CMAKE_SYSTEM MATCHES "SunOS.*")
-  target_link_libraries(${METAIO_TARGET} PRIVATE socket nsl)
-endif()
 
 target_link_libraries(${METAIO_TARGET} PUBLIC
   ${METAIO_LIBXML2_LIBRARIES}

--- a/src/localMetaConfiguration.h
+++ b/src/localMetaConfiguration.h
@@ -26,8 +26,9 @@
 
 #  define METAIO_USE_NAMESPACE 0
 #  define METAIO_NAMESPACE ITKMetaIO
-#  define METAIO_STREAM std
+#  define METAIO_STREAM itksys
 
+#  include <itksys/FStream.hxx>
 #  include <itk_zlib.h>
 
 #  include <iostream>

--- a/src/localMetaConfiguration.h
+++ b/src/localMetaConfiguration.h
@@ -21,26 +21,29 @@
 
 #include "metaIOConfig.h"
 
-#if defined(METAIO_FOR_ITK) || !defined(METAIO_FOR_VTK)
+#if defined(METAIO_FOR_ITK)
 // ITK
 
 #  define METAIO_USE_NAMESPACE 0
 #  define METAIO_NAMESPACE ITKMetaIO
+#  define METAIO_STREAM std
 
-#  include "itk_zlib.h"
+#  include <itk_zlib.h>
 
 #  include <iostream>
 #  include <fstream>
 
 #  define METAIO_EXPORT
 
-#else
+#elif defined(METAIO_FOR_VTK)
 // VTK
 
 #  define METAIO_USE_NAMESPACE 1
 #  define METAIO_NAMESPACE vtkmetaio
+#  define METAIO_STREAM vtksys
 
-#  include "vtk_zlib.h"
+#  include <vtksys/FStream.hxx>
+#  include <vtk_zlib.h>
 
 #  include <iostream>
 #  include <fstream>
@@ -57,5 +60,18 @@
 #    define METAIO_EXPORT
 #  endif
 
-// end VTK/ITK
+#else
+// Independent of ITK and VTK
+
+#  define METAIO_USE_NAMESPACE 0
+#  define METAIO_NAMESPACE metaio
+#  define METAIO_STREAM std
+
+#  include "zlib.h"
+
+#  include <iostream>
+#  include <fstream>
+
+#  define METAIO_EXPORT
+
 #endif

--- a/src/localMetaConfiguration.h
+++ b/src/localMetaConfiguration.h
@@ -68,7 +68,7 @@
 #  define METAIO_NAMESPACE metaio
 #  define METAIO_STREAM std
 
-#  include "zlib.h"
+#  include "itk_zlib.h"
 
 #  include <iostream>
 #  include <fstream>

--- a/src/metaArray.cxx
+++ b/src/metaArray.cxx
@@ -552,7 +552,7 @@ MetaArray::CanRead(const char * _headerName) const
   }
 
   // Now check the file content
-  std::ifstream inputStream;
+  METAIO_STREAM::ifstream inputStream;
 
 #ifdef __sgi
   inputStream.open(_headerName, std::ios::in);
@@ -581,7 +581,7 @@ MetaArray::Read(const char * _headerName, bool _readElements, void * _elementDat
     m_FileName = _headerName;
   }
 
-  auto * tmpStream = new std::ifstream;
+  auto * tmpStream = new METAIO_STREAM::ifstream;
 
 #ifdef __sgi
   tmpStream->open(m_FileName, std::ios::in);
@@ -612,7 +612,7 @@ MetaArray::Read(const char * _headerName, bool _readElements, void * _elementDat
 
 
 bool
-MetaArray::CanReadStream(std::ifstream * _stream) const
+MetaArray::CanReadStream(METAIO_STREAM::ifstream * _stream) const
 {
   if (!strncmp(MET_ReadForm(*_stream).c_str(), "Array", 5))
   {
@@ -622,7 +622,7 @@ MetaArray::CanReadStream(std::ifstream * _stream) const
 }
 
 bool
-MetaArray::ReadStream(std::ifstream * _stream, bool _readElements, void * _elementDataBuffer, bool _autoFreeElementData)
+MetaArray::ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements, void * _elementDataBuffer, bool _autoFreeElementData)
 {
   META_DEBUG_PRINT( "MetaArray: ReadStream" );
 
@@ -671,7 +671,7 @@ MetaArray::ReadStream(std::ifstream * _stream, bool _readElements, void * _eleme
       {
         fName = m_ElementDataFileName;
       }
-      auto * readStreamTemp = new std::ifstream;
+      auto * readStreamTemp = new METAIO_STREAM::ifstream;
 
 #ifdef __sgi
       readStreamTemp->open(fName, std::ios::in);
@@ -756,13 +756,13 @@ MetaArray::Write(const char * _headName, const char * _dataName, bool _writeElem
     }
   }
 
-  auto * tmpWriteStream = new std::ofstream;
+  auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
 // Some older sgi compilers have a error in the ofstream constructor
 // that requires a file to exist for output
 #ifdef __sgi
   {
-    std::ofstream tFile(m_FileName, std::ios::out);
+    METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
     tFile.close();
   }
   tmpWriteStream->open(m_FileName, std::ios::out);
@@ -795,7 +795,7 @@ MetaArray::Write(const char * _headName, const char * _dataName, bool _writeElem
 }
 
 bool
-MetaArray::WriteStream(std::ofstream * _stream, bool _writeElements, const void * _constElementData)
+MetaArray::WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements, const void * _constElementData)
 {
   if (m_WriteStream != nullptr)
   {
@@ -989,7 +989,7 @@ MetaArray::M_Read()
 }
 
 bool
-MetaArray::M_ReadElements(std::ifstream * _fstream, void * _data, int _dataQuantity)
+MetaArray::M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, int _dataQuantity)
 {
   META_DEBUG_PRINT( "MetaArray: M_ReadElements" );
 
@@ -1044,10 +1044,10 @@ MetaArray::M_ReadElements(std::ifstream * _fstream, void * _data, int _dataQuant
 }
 
 bool
-MetaArray::M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
+MetaArray::M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
 {
   bool            localData;
-  std::ofstream * tmpWriteStream;
+  METAIO_STREAM::ofstream * tmpWriteStream;
   if (m_ElementDataFileName == "LOCAL")
   {
     localData = true;
@@ -1056,7 +1056,7 @@ MetaArray::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
   else
   {
     localData = false;
-    tmpWriteStream = new std::ofstream;
+    tmpWriteStream = new METAIO_STREAM::ofstream;
 
     std::string dataFileName;
     std::string pathName;
@@ -1074,7 +1074,7 @@ MetaArray::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
 // that requires a file to exist for output
 #ifdef __sgi
     {
-      std::ofstream tFile(dataFileName, std::ios::out);
+      METAIO_STREAM::ofstream tFile(dataFileName, std::ios::out);
       tFile.close();
     }
     tmpWriteStream->open(dataFileName, std::ios::out);

--- a/src/metaArray.cxx
+++ b/src/metaArray.cxx
@@ -554,11 +554,7 @@ MetaArray::CanRead(const char * _headerName) const
   // Now check the file content
   METAIO_STREAM::ifstream inputStream;
 
-#ifdef __sgi
-  inputStream.open(_headerName, std::ios::in);
-#else
   inputStream.open(_headerName, std::ios::in | std::ios::binary);
-#endif
 
   if (!inputStream.rdbuf()->is_open())
   {
@@ -583,11 +579,7 @@ MetaArray::Read(const char * _headerName, bool _readElements, void * _elementDat
 
   auto * tmpStream = new METAIO_STREAM::ifstream;
 
-#ifdef __sgi
-  tmpStream->open(m_FileName, std::ios::in);
-#else
-  tmpStream->open(m_FileName, std::ios::in | std::ios::binary);
-#endif
+  tmpStream->open(m_FileName.c_str(), std::ios::in | std::ios::binary);
 
   if (!tmpStream->rdbuf()->is_open())
   {
@@ -673,11 +665,7 @@ MetaArray::ReadStream(METAIO_STREAM::ifstream * _stream, bool _readElements, voi
       }
       auto * readStreamTemp = new METAIO_STREAM::ifstream;
 
-#ifdef __sgi
-      readStreamTemp->open(fName, std::ios::in);
-#else
-      readStreamTemp->open(fName, std::ios::binary | std::ios::in);
-#endif
+      readStreamTemp->open(fName.c_str(), std::ios::binary | std::ios::in);
       if (!readStreamTemp->rdbuf()->is_open())
       {
         std::cout << "MetaArray: Read: Cannot open data file" << '\n';
@@ -758,17 +746,7 @@ MetaArray::Write(const char * _headName, const char * _dataName, bool _writeElem
 
   auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
-// Some older sgi compilers have a error in the ofstream constructor
-// that requires a file to exist for output
-#ifdef __sgi
-  {
-    METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
-    tFile.close();
-  }
-  tmpWriteStream->open(m_FileName, std::ios::out);
-#else
-  tmpWriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  tmpWriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!tmpWriteStream->rdbuf()->is_open())
   {
@@ -1070,17 +1048,7 @@ MetaArray::M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _dat
       dataFileName = m_ElementDataFileName;
     }
 
-// Some older sgi compilers have a error in the ofstream constructor
-// that requires a file to exist for output
-#ifdef __sgi
-    {
-      METAIO_STREAM::ofstream tFile(dataFileName, std::ios::out);
-      tFile.close();
-    }
-    tmpWriteStream->open(dataFileName, std::ios::out);
-#else
-    tmpWriteStream->open(dataFileName, std::ios::binary | std::ios::out);
-#endif
+    tmpWriteStream->open(dataFileName.c_str(), std::ios::binary | std::ios::out);
   }
 
   if (!m_BinaryData)

--- a/src/metaArray.h
+++ b/src/metaArray.h
@@ -159,10 +159,10 @@ public:
        bool         _autoFreeElementData = false);
 
   virtual bool
-  CanReadStream(std::ifstream * _stream) const;
+  CanReadStream(METAIO_STREAM::ifstream * _stream) const;
 
   virtual bool
-  ReadStream(std::ifstream * _stream,
+  ReadStream(METAIO_STREAM::ifstream * _stream,
              bool            _readElements = true,
              void *          _elementDataBuffer = nullptr,
              bool            _autoFreeElementData = false);
@@ -174,7 +174,7 @@ public:
         const void * _constElementData = nullptr);
 
   virtual bool
-  WriteStream(std::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
+  WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
 
   // PROTECTED
 protected:
@@ -205,10 +205,10 @@ protected:
   M_Read() override;
 
   bool
-  M_ReadElements(std::ifstream * _fstream, void * _data, int _dataQuantity);
+  M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, int _dataQuantity);
 
   bool
-  M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
+  M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
 };
 
 #  if (METAIO_USE_NAMESPACE)

--- a/src/metaCommand.cxx
+++ b/src/metaCommand.cxx
@@ -1363,7 +1363,7 @@ MetaCommand::ExportGAD(bool dynamic)
   std::string filename = m_Name;
   filename += ".gad.xml";
 
-  std::ofstream file;
+  METAIO_STREAM::ofstream file;
 #ifdef __sgi
   file.open(filename.c_str(), std::ios::out);
 #else

--- a/src/metaForm.cxx
+++ b/src/metaForm.cxx
@@ -546,7 +546,7 @@ MetaForm::Read(const char * _fileName)
 
   std::cout << "Read FileName = _" << m_FileName << "_" << '\n';
 
-  auto * tmpReadStream = new std::ifstream;
+  auto * tmpReadStream = new METAIO_STREAM::ifstream;
 #ifdef __sgi
   tmpReadStream->open(m_FileName, std::ios::in);
 #else
@@ -576,7 +576,7 @@ MetaForm::Read(const char * _fileName)
 }
 
 bool
-MetaForm::CanReadStream(std::ifstream * _stream)
+MetaForm::CanReadStream(METAIO_STREAM::ifstream * _stream)
 {
   if (_stream)
   {
@@ -589,7 +589,7 @@ MetaForm::CanReadStream(std::ifstream * _stream)
 }
 
 bool
-MetaForm::ReadStream(std::ifstream * _stream)
+MetaForm::ReadStream(METAIO_STREAM::ifstream * _stream)
 {
   META_DEBUG_PRINT( "MetaForm: ReadStream" );
 
@@ -623,12 +623,12 @@ MetaForm::Write(const char * _fileName)
 
   std::cout << "Write FileName = _" << m_FileName << "_" << '\n';
 
-  auto * tmpWriteStream = new std::ofstream;
+  auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
 #ifdef __sgi
   {
     // Create the file. This is required on some older sgi's
-    std::ofstream tFile(m_FileName, std::ios::out);
+    METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
     tFile.close();
   }
   tmpWriteStream->open(m_FileName, std::ios::out);
@@ -653,7 +653,7 @@ MetaForm::Write(const char * _fileName)
 }
 
 bool
-MetaForm::WriteStream(std::ofstream * _stream)
+MetaForm::WriteStream(METAIO_STREAM::ofstream * _stream)
 {
   M_SetupWriteFields();
 

--- a/src/metaForm.cxx
+++ b/src/metaForm.cxx
@@ -547,11 +547,7 @@ MetaForm::Read(const char * _fileName)
   std::cout << "Read FileName = _" << m_FileName << "_" << '\n';
 
   auto * tmpReadStream = new METAIO_STREAM::ifstream;
-#ifdef __sgi
-  tmpReadStream->open(m_FileName, std::ios::in);
-#else
-  tmpReadStream->open(m_FileName, std::ios::binary | std::ios::in);
-#endif
+  tmpReadStream->open(m_FileName.c_str(), std::ios::binary | std::ios::in);
 
   if (!tmpReadStream->rdbuf()->is_open())
   {
@@ -625,16 +621,7 @@ MetaForm::Write(const char * _fileName)
 
   auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
-#ifdef __sgi
-  {
-    // Create the file. This is required on some older sgi's
-    METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
-    tFile.close();
-  }
-  tmpWriteStream->open(m_FileName, std::ios::out);
-#else
-  tmpWriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  tmpWriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!tmpWriteStream->rdbuf()->is_open())
   {

--- a/src/metaForm.h
+++ b/src/metaForm.h
@@ -159,23 +159,23 @@ public:
   Read(const char * _fileName = nullptr);
 
   static bool
-  CanReadStream(std::ifstream * _stream) ;
+  CanReadStream(METAIO_STREAM::ifstream * _stream) ;
 
   bool
-  ReadStream(std::ifstream * _stream);
+  ReadStream(METAIO_STREAM::ifstream * _stream);
 
   bool
   Write(const char * _fileName = nullptr);
 
   bool
-  WriteStream(std::ofstream * _stream);
+  WriteStream(METAIO_STREAM::ofstream * _stream);
 
   // PROTECTED
 protected:
   typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
-  std::ifstream * m_ReadStream;
-  std::ofstream * m_WriteStream;
+  METAIO_STREAM::ifstream * m_ReadStream;
+  METAIO_STREAM::ofstream * m_WriteStream;
 
   std::string m_FileName;
 

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -37,40 +37,19 @@ namespace
 void
 openReadStream(METAIO_STREAM::ifstream & inputStream, const std::string & fname)
 {
-#ifdef __sgi
-  inputStream.open(fname, std::ios::in);
-#else
-  inputStream.open(fname, std::ios::in | std::ios::binary);
-#endif
+  inputStream.open(fname.c_str(), std::ios::in | std::ios::binary);
 }
 
 void
 openWriteStream(METAIO_STREAM::ofstream & outputStream, const std::string & fname, bool append)
 {
-// Some older sgi compilers have a error in the ofstream constructor
-// that requires a file to exist for output
-#ifdef __sgi
-  {
-    METAIO_STREAM::ofstream tFile(fname, std::ios::out);
-    tFile.close();
-  }
-#endif
-
   if (!append)
   {
-#ifdef __sgi
-    outputStream.open(fname, std::ios::out);
-#else
-    outputStream.open(fname, std::ios::binary | std::ios::out);
-#endif
+    outputStream.open(fname.c_str(), std::ios::binary | std::ios::out);
   }
   else
   {
-#ifdef __sgi
-    outputStream.open(fname, std::ios::app | std::ios::out);
-#else
-    outputStream.open(fname, std::ios::binary | std::ios::app | std::ios::out);
-#endif
+    outputStream.open(fname.c_str(), std::ios::binary | std::ios::app | std::ios::out);
   }
 }
 
@@ -1676,7 +1655,7 @@ MetaImage::WriteROI(int *        _indexMin,
 
     // Find the start of the data
     auto * readStream = new METAIO_STREAM::ifstream;
-    readStream->open(m_FileName, std::ios::binary | std::ios::in);
+    readStream->open(m_FileName.c_str(), std::ios::binary | std::ios::in);
 
     // File must be readable
     if (!MetaObject::ReadStream(m_NDims, readStream))

--- a/src/metaImage.cxx
+++ b/src/metaImage.cxx
@@ -35,7 +35,7 @@ namespace
 {
 
 void
-openReadStream(std::ifstream & inputStream, const std::string & fname)
+openReadStream(METAIO_STREAM::ifstream & inputStream, const std::string & fname)
 {
 #ifdef __sgi
   inputStream.open(fname, std::ios::in);
@@ -45,13 +45,13 @@ openReadStream(std::ifstream & inputStream, const std::string & fname)
 }
 
 void
-openWriteStream(std::ofstream & outputStream, const std::string & fname, bool append)
+openWriteStream(METAIO_STREAM::ofstream & outputStream, const std::string & fname, bool append)
 {
 // Some older sgi compilers have a error in the ofstream constructor
 // that requires a file to exist for output
 #ifdef __sgi
   {
-    std::ofstream tFile(fname, std::ios::out);
+    METAIO_STREAM::ofstream tFile(fname, std::ios::out);
     tFile.close();
   }
 #endif
@@ -1111,7 +1111,7 @@ MetaImage::CanRead(const char * _headerName)
   }
 
   // Now check the file content
-  std::ifstream inputStream;
+  METAIO_STREAM::ifstream inputStream;
 
   openReadStream(inputStream, fname);
 
@@ -1156,7 +1156,7 @@ MetaObject::M_Destroy();
 
   M_PrepareNewReadStream();
 
-  auto * tmpReadStream = new std::ifstream;
+  auto * tmpReadStream = new METAIO_STREAM::ifstream;
 
   openReadStream(*tmpReadStream, m_FileName);
 
@@ -1181,7 +1181,7 @@ MetaObject::M_Destroy();
 }
 
 bool
-MetaImage::CanReadStream(std::ifstream * _stream)
+MetaImage::CanReadStream(METAIO_STREAM::ifstream * _stream)
 {
   if (!strncmp(MET_ReadType(*_stream).c_str(), "Image", 5))
   {
@@ -1192,7 +1192,7 @@ MetaImage::CanReadStream(std::ifstream * _stream)
 
 
 bool
-MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, void * _buffer)
+MetaImage::ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream, bool _readElements, void * _buffer)
 {
   if (!MetaObject::ReadStream(_nDims, _stream))
   {
@@ -1249,7 +1249,7 @@ MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, v
         fileImageDim = m_NDims - 1;
       }
       std::string s;
-      auto *      readStreamTemp = new std::ifstream;
+      auto *      readStreamTemp = new METAIO_STREAM::ifstream;
       int         elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
       elementSize *= m_ElementNumberOfChannels;
@@ -1310,7 +1310,7 @@ MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, v
       int         maxV = m_DimSize[m_NDims - 1];
       int         stepV = 1;
       std::string s;
-      auto *      readStreamTemp = new std::ifstream;
+      auto *      readStreamTemp = new METAIO_STREAM::ifstream;
       MET_StringToWordArray(m_ElementDataFileName.c_str(), &nWrds, &wrds);
       if (nWrds >= 2)
       {
@@ -1422,7 +1422,7 @@ MetaImage::ReadStream(int _nDims, std::ifstream * _stream, bool _readElements, v
         fName = m_ElementDataFileName;
       }
 
-      auto * readStreamTemp = new std::ifstream;
+      auto * readStreamTemp = new METAIO_STREAM::ifstream;
 
       const char * extensions[] = { "", ".gz", ".Z", nullptr };
       for (unsigned ii = 0; extensions[ii] != nullptr; ii++)
@@ -1537,7 +1537,7 @@ MetaImage::Write(const char * _headName,
     }
   }
 
-  auto * tmpWriteStream = new std::ofstream;
+  auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
   openWriteStream(*tmpWriteStream, m_FileName, _append);
 
@@ -1567,7 +1567,7 @@ MetaImage::Write(const char * _headName,
 }
 
 bool
-MetaImage::WriteStream(std::ofstream * _stream, bool _writeElements, const void * _constElementData)
+MetaImage::WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements, const void * _constElementData)
 {
   if (m_WriteStream != nullptr)
   {
@@ -1675,7 +1675,7 @@ MetaImage::WriteROI(int *        _indexMin,
     }
 
     // Find the start of the data
-    auto * readStream = new std::ifstream;
+    auto * readStream = new METAIO_STREAM::ifstream;
     readStream->open(m_FileName, std::ios::binary | std::ios::in);
 
     // File must be readable
@@ -1731,7 +1731,7 @@ MetaImage::WriteROI(int *        _indexMin,
       filename = pathName + filename;
     }
 
-    auto * tmpWriteStream = new std::ofstream;
+    auto * tmpWriteStream = new METAIO_STREAM::ofstream;
     tmpWriteStream->open(filename.c_str(), std::ios::binary | std::ios::in | std::ios::out);
 
     if (!tmpWriteStream->is_open())
@@ -1843,7 +1843,7 @@ MetaImage::WriteROI(int *        _indexMin,
       }
     }
 
-    auto * tmpWriteStream = new std::ofstream;
+    auto * tmpWriteStream = new METAIO_STREAM::ofstream;
 
     openWriteStream(*tmpWriteStream, m_FileName, _append);
 
@@ -1927,7 +1927,7 @@ MetaImage::WriteROI(int *        _indexMin,
 }
 
 bool
-MetaImage::M_WriteElementsROI(std::ofstream * _fstream,
+MetaImage::M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
                               const void *    _data,
                               std::streampos  _dataPos,
                               const int *     _indexMin,
@@ -2345,7 +2345,7 @@ MetaImage::M_Read()
 }
 
 bool
-MetaImage::M_ReadElements(std::ifstream * _fstream, void * _data, std::streamoff _dataQuantity)
+MetaImage::M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, std::streamoff _dataQuantity)
 {
   META_DEBUG_PRINT( "MetaImage: M_ReadElements" );
 
@@ -2424,7 +2424,7 @@ MetaImage::M_ReadElements(std::ifstream * _fstream, void * _data, std::streamoff
 }
 
 bool
-MetaImage::M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
+MetaImage::M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
 {
 
   if (m_ElementDataFileName == "LOCAL")
@@ -2457,7 +2457,7 @@ MetaImage::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
       std::streamoff elementNumberOfBytes = elementSize * m_ElementNumberOfChannels;
       std::streamoff sliceNumberOfBytes = m_SubQuantity[m_NDims - 1] * elementNumberOfBytes;
 
-      auto * writeStreamTemp = new std::ofstream;
+      auto * writeStreamTemp = new METAIO_STREAM::ofstream;
       for (i = 1; i <= m_DimSize[m_NDims - 1]; i++)
       {
         fName = string_format(dataFileName, i);
@@ -2506,7 +2506,7 @@ MetaImage::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
     }
     else // write the image in one unique other file
     {
-      auto * writeStreamTemp = new std::ofstream;
+      auto * writeStreamTemp = new METAIO_STREAM::ofstream;
       openWriteStream(*writeStreamTemp, dataFileName, false);
 
       if (!MetaImage::M_WriteElementData(writeStreamTemp, _data, _dataQuantity))
@@ -2526,7 +2526,7 @@ MetaImage::M_WriteElements(std::ofstream * _fstream, const void * _data, std::st
 
 
 bool
-MetaImage::M_WriteElementData(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
+MetaImage::M_WriteElementData(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity)
 {
   if (!m_BinaryData)
   {
@@ -2609,7 +2609,7 @@ MetaObject::M_Destroy();
 
   M_PrepareNewReadStream();
 
-  auto * tmpReadStream = new std::ifstream;
+  auto * tmpReadStream = new METAIO_STREAM::ifstream;
 
   openReadStream(*tmpReadStream, m_FileName);
 
@@ -2638,7 +2638,7 @@ bool
 MetaImage::ReadROIStream(int *           _indexMin,
                          int *           _indexMax,
                          int             _nDims,
-                         std::ifstream * _stream,
+                         METAIO_STREAM::ifstream * _stream,
                          bool            _readElements,
                          void *          _buffer,
                          unsigned int    subSamplingFactor)
@@ -2694,7 +2694,7 @@ MetaImage::ReadROIStream(int *           _indexMin,
       }
       delete[] wrds;
       char   s[1024];
-      auto * readStreamTemp = new std::ifstream;
+      auto * readStreamTemp = new METAIO_STREAM::ifstream;
       int    elementSize;
       MET_SizeOfType(m_ElementType, &elementSize);
       elementSize *= m_ElementNumberOfChannels;
@@ -2781,7 +2781,7 @@ MetaImage::ReadROIStream(int *           _indexMin,
       int         maxV;
       int         stepV = 1;
       std::string s;
-      auto *      readStreamTemp = new std::ifstream;
+      auto *      readStreamTemp = new METAIO_STREAM::ifstream;
       MET_StringToWordArray(m_ElementDataFileName.c_str(), &nWrds, &wrds);
       if (nWrds >= 2)
       {
@@ -2914,7 +2914,7 @@ MetaImage::ReadROIStream(int *           _indexMin,
         fName = m_ElementDataFileName;
       }
 
-      auto * readStreamTemp = new std::ifstream;
+      auto * readStreamTemp = new METAIO_STREAM::ifstream;
 
       const char * extensions[] = { "", ".gz", ".Z", nullptr };
       for (unsigned ii = 0; extensions[ii] != nullptr; ii++)
@@ -2960,7 +2960,7 @@ MetaImage::ReadROIStream(int *           _indexMin,
 
 /** Read an ROI */
 bool
-MetaImage::M_ReadElementsROI(std::ifstream * _fstream,
+MetaImage::M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream,
                              void *          _data,
                              std::streamoff  _dataQuantity,
                              int *           _indexMin,
@@ -3286,7 +3286,7 @@ MetaImage::M_ReadElementsROI(std::ifstream * _fstream,
 
 
 bool
-MetaImage::M_ReadElementData(std::ifstream * _fstream, void * _data, std::streamoff _dataQuantity)
+MetaImage::M_ReadElementData(METAIO_STREAM::ifstream * _fstream, void * _data, std::streamoff _dataQuantity)
 {
   // NOTE: this method is different from WriteElementData
   std::streamoff gc = 0;

--- a/src/metaImage.h
+++ b/src/metaImage.h
@@ -303,16 +303,16 @@ public:
 
 
   static bool
-  CanReadStream(std::ifstream * _stream) ;
+  CanReadStream(METAIO_STREAM::ifstream * _stream) ;
 
   bool
-  ReadStream(int _nDims, std::ifstream * _stream, bool _readElements = true, void * _buffer = nullptr);
+  ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream, bool _readElements = true, void * _buffer = nullptr);
 
   bool
   ReadROIStream(int *           _indexMin,
                 int *           _indexMax,
                 int             _nDims,
-                std::ifstream * _stream,
+                METAIO_STREAM::ifstream * _stream,
                 bool            _readElements = true,
                 void *          _buffer = nullptr,
                 unsigned int    subSamplingFactor = 1);
@@ -340,7 +340,7 @@ public:
            bool         _append = false);
 
   bool
-  WriteStream(std::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
+  WriteStream(METAIO_STREAM::ofstream * _stream, bool _writeElements = true, const void * _constElementData = nullptr);
 
 
   bool
@@ -402,13 +402,13 @@ protected:
   // _dataQuantity is expressed in number of pixels. Internally it will be
   // scaled by the number of components and number of bytes per component.
   bool
-  M_ReadElements(std::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
+  M_ReadElements(METAIO_STREAM::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
 
   // _totalDataQuantity and _dataQuantity are expressed in number of pixels.
   // Internally they will be scaled by the number of components and number of
   // bytes per component.
   bool
-  M_ReadElementsROI(std::ifstream * _fstream,
+  M_ReadElementsROI(METAIO_STREAM::ifstream * _fstream,
                     void *          _data,
                     std::streamoff  _dataQuantity,
                     int *           _indexMin,
@@ -417,20 +417,20 @@ protected:
                     std::streamoff  _totalDataQuantity = 0);
 
   bool
-  M_ReadElementData(std::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
+  M_ReadElementData(METAIO_STREAM::ifstream * _fstream, void * _data, std::streamoff _dataQuantity);
 
   bool
-  M_WriteElements(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
+  M_WriteElements(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
 
   bool
-  M_WriteElementsROI(std::ofstream * _fstream,
+  M_WriteElementsROI(METAIO_STREAM::ofstream * _fstream,
                      const void *    _data,
                      std::streampos  _dataPos,
                      const int *     _indexMin,
                      const int *     _indexMax);
 
   bool
-  M_WriteElementData(std::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
+  M_WriteElementData(METAIO_STREAM::ofstream * _fstream, const void * _data, std::streamoff _dataQuantity);
 
   static bool
   M_FileExists(const char * filename) ;

--- a/src/metaMesh.h
+++ b/src/metaMesh.h
@@ -115,7 +115,7 @@ public:
   virtual ~MeshDataBase() = default;
 
   virtual void
-  Write(std::ofstream * stream) = 0;
+  Write(METAIO_STREAM::ofstream * stream) = 0;
   virtual unsigned int
   GetSize() = 0;
   virtual MET_ValueEnumType
@@ -123,8 +123,8 @@ public:
   int m_Id;
 
 protected:
-  std::ifstream * m_ReadStream{};
-  std::ofstream * m_WriteStream{};
+  METAIO_STREAM::ifstream * m_ReadStream{};
+  METAIO_STREAM::ofstream * m_WriteStream{};
 };
 
 /** Mesh point data class for basic types (i.e int, float ... ) */
@@ -142,7 +142,7 @@ public:
   }
 
   void
-  Write(std::ofstream * stream) override
+  Write(METAIO_STREAM::ofstream * stream) override
   {
     // char* id = new char[sizeof(int)];
     // The file is written as LSB by default

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -273,11 +273,7 @@ MetaObject::Read(const char * _fileName)
 
   auto * tmpReadStream = new METAIO_STREAM::ifstream;
 
-#ifdef __sgi
-  tmpReadStream->open(m_FileName, std::ios::in);
-#else
-  tmpReadStream->open(m_FileName, std::ios::binary | std::ios::in);
-#endif
+  tmpReadStream->open(m_FileName.c_str(), std::ios::binary | std::ios::in);
 
   if (!tmpReadStream->rdbuf()->is_open())
   {
@@ -347,14 +343,7 @@ MetaObject::Write(const char * _fileName)
     m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
-#ifdef __sgi
-  // Create the file. This is required on some older sgi's
-  METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
-  tFile.close();
-  m_WriteStream->open(m_FileName, std::ios::out);
-#else
-  m_WriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  m_WriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!m_WriteStream->rdbuf()->is_open())
   {
@@ -1735,24 +1724,13 @@ MetaObject ::Append(const char * _headName)
     m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
-#ifdef __sgi
-  m_WriteStream->open(m_FileName, std::ios::out | std::ios::in);
-  if (!m_WriteStream->rdbuf()->is_open())
-  {
-    delete m_WriteStream;
-    m_WriteStream = 0;
-    return false;
-  }
-  m_WriteStream->seekp(0, std::ios::end);
-#else
-  m_WriteStream->open(m_FileName, std::ios::binary | std::ios::out | std::ios::app);
+  m_WriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out | std::ios::app);
   if (!m_WriteStream->rdbuf()->is_open())
   {
     delete m_WriteStream;
     m_WriteStream = nullptr;
     return false;
   }
-#endif
 
   M_Write();
 

--- a/src/metaObject.cxx
+++ b/src/metaObject.cxx
@@ -271,7 +271,7 @@ MetaObject::Read(const char * _fileName)
     m_FileName = _fileName;
   }
 
-  auto * tmpReadStream = new std::ifstream;
+  auto * tmpReadStream = new METAIO_STREAM::ifstream;
 
 #ifdef __sgi
   tmpReadStream->open(m_FileName, std::ios::in);
@@ -301,7 +301,7 @@ MetaObject::Read(const char * _fileName)
 
 
 bool
-MetaObject::ReadStream(int _nDims, std::ifstream * _stream)
+MetaObject::ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream)
 {
   META_DEBUG_PRINT( "MetaObject: ReadStream" );
 
@@ -344,12 +344,12 @@ MetaObject::Write(const char * _fileName)
 
   if (!m_WriteStream)
   {
-    m_WriteStream = new std::ofstream;
+    m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
 #ifdef __sgi
   // Create the file. This is required on some older sgi's
-  std::ofstream tFile(m_FileName, std::ios::out);
+  METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
   tFile.close();
   m_WriteStream->open(m_FileName, std::ios::out);
 #else
@@ -1732,7 +1732,7 @@ MetaObject ::Append(const char * _headName)
 
   if (!m_WriteStream)
   {
-    m_WriteStream = new std::ofstream;
+    m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
 #ifdef __sgi
@@ -1856,7 +1856,7 @@ MetaObject::M_PrepareNewReadStream()
   }
   else
   {
-    m_ReadStream = new std::ifstream;
+    m_ReadStream = new METAIO_STREAM::ifstream;
   }
 }
 

--- a/src/metaObject.h
+++ b/src/metaObject.h
@@ -56,8 +56,8 @@ protected:
 
   typedef std::vector<MET_FieldRecordType *> FieldsContainerType;
 
-  std::ifstream * m_ReadStream;
-  std::ofstream * m_WriteStream;
+  METAIO_STREAM::ifstream * m_ReadStream;
+  METAIO_STREAM::ofstream * m_WriteStream;
 
   FieldsContainerType m_Fields;
   FieldsContainerType m_UserDefinedWriteFields;
@@ -154,7 +154,7 @@ public:
   Read(const char * _fileName = nullptr);
 
   bool
-  ReadStream(int _nDims, std::ifstream * _stream);
+  ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream);
 
   virtual bool
   Write(const char * _fileName = nullptr);

--- a/src/metaScene.cxx
+++ b/src/metaScene.cxx
@@ -343,13 +343,13 @@ MetaScene::Write(const char * _headName)
 
   if (!m_WriteStream)
   {
-    m_WriteStream = new std::ofstream;
+    m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
 #ifdef __sgi
   // Create the file. This is required on some older sgi's
   {
-    std::ofstream tFile(m_FileName, std::ios::out);
+    METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
     tFile.close();
   }
   m_WriteStream->open(m_FileName, std::ios::out);

--- a/src/metaScene.cxx
+++ b/src/metaScene.cxx
@@ -130,7 +130,7 @@ MetaObject::M_Destroy();
 
   M_PrepareNewReadStream();
 
-  m_ReadStream->open(m_FileName, std::ios::binary | std::ios::in);
+  m_ReadStream->open(m_FileName.c_str(), std::ios::binary | std::ios::in);
 
   if (!m_ReadStream->rdbuf()->is_open())
   {
@@ -346,16 +346,7 @@ MetaScene::Write(const char * _headName)
     m_WriteStream = new METAIO_STREAM::ofstream;
   }
 
-#ifdef __sgi
-  // Create the file. This is required on some older sgi's
-  {
-    METAIO_STREAM::ofstream tFile(m_FileName, std::ios::out);
-    tFile.close();
-  }
-  m_WriteStream->open(m_FileName, std::ios::out);
-#else
-  m_WriteStream->open(m_FileName, std::ios::binary | std::ios::out);
-#endif
+  m_WriteStream->open(m_FileName.c_str(), std::ios::binary | std::ios::out);
 
   if (!m_WriteStream->rdbuf()->is_open())
   {

--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -590,7 +590,7 @@ MET_ValueToValue(MET_ValueEnumType _fromType,
 // Uncompress a stream given an uncompressedSeekPosition
 METAIO_EXPORT
 std::streamoff
-MET_UncompressStream(std::ifstream *            stream,
+MET_UncompressStream(METAIO_STREAM::ifstream *            stream,
                      std::streamoff             uncompressedSeekPosition,
                      unsigned char *            uncompressedData,
                      std::streamoff             uncompressedDataSize,

--- a/src/metaUtils.h
+++ b/src/metaUtils.h
@@ -349,7 +349,7 @@ MET_PerformUncompression(const unsigned char * sourceCompressed,
 // Uncompress a stream given an uncompressedSeekPosition
 METAIO_EXPORT
 std::streamoff
-MET_UncompressStream(std::ifstream *            stream,
+MET_UncompressStream(METAIO_STREAM::ifstream *            stream,
                      std::streamoff             uncompressedSeekPosition,
                      unsigned char *            uncompressedData,
                      std::streamoff             uncompressedDataSize,


### PR DESCRIPTION
Addresses the following issues:

https://github.com/Kitware/MetaIO/issues/106

https://github.com/Kitware/MetaIO/pull/113

Also, for VTK:
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6716#note_908828

Of course, VTK seems to have dropped MetaIO support, but most medical imaging apps that use VTK actually use ITK for IO, so these fixes are still relevant to that community.

All ITK tests pass with these changes.

Thoughts?
@todoooo
@codeling 
@hjmjohnson 