### PR TITLE
BUG: Memory leak in GetObjectSubType due to unused tag/record

### DIFF
--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -162,7 +162,6 @@ MET_ReadType(std::istream & _fp)
   std::vector<MET_FieldRecordType *> fields;
   auto *                             mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "ObjectType", MET_STRING, false);
-  mF->required = false;
   mF->terminateRead = true;
   fields.push_back(mF);
 
@@ -190,12 +189,8 @@ MET_ReadSubType(std::istream & _fp)
   std::vector<MET_FieldRecordType *> fields;
   MET_FieldRecordType *              mF;
   mF = new MET_FieldRecordType;
-  MET_InitReadField(mF, "ObjectType", MET_STRING, false);
-  mF->required = false;
-  fields.push_back(mF);
-  mF = new MET_FieldRecordType;
   MET_InitReadField(mF, "ObjectSubType", MET_STRING, false);
-  mF->required = false;
+  mF->terminateRead = true;
   fields.push_back(mF);
 
   MET_Read(_fp, &fields, '=', true, false);


### PR DESCRIPTION
GetObjectSubType reading was also reading ObjectType from the file, and that wasn't necessary and produced a memory leak.   This commit fixes those issues.

Also, now the file parsing terminates when ObjectSubType has been read by the GetObjectSubType() function - avoiding parsing of the entire file.