### PR TITLE
metaUtils: require Z_STREAM_END when validating uncompressed data

### DIFF
--- a/src/metaUtils.cxx
+++ b/src/metaUtils.cxx
@@ -891,6 +891,12 @@ MET_PerformUncompression(const unsigned char * sourceCompressed,
     } while (d_stream.avail_out == 0);
   } while (err != Z_STREAM_END && err >= 0);
   inflateEnd(&d_stream);
+  if (err != Z_STREAM_END)
+  {
+    std::cerr << "MET_PerformUncompression: compressed stream did not terminate cleanly (zlib error " << err << ")"
+              << '\n';
+    return false;
+  }
   if (dest_pos != uncompressedDataSize)
   {
     std::cerr << "MET_PerformUncompression: expected " << uncompressedDataSize << " bytes, produced " << dest_pos


### PR DESCRIPTION
Require `Z_STREAM_END` in `MET_PerformUncompression`, not just the expected byte count, so a compressed stream truncated exactly at the declared output size is rejected instead of silently accepted. Fixes #144; hardens the byte-count check from #142.

<details>
<summary>Root cause</summary>

When the decompressed data fills the destination buffer exactly, the last `inflate()` returns `Z_OK` and the next call (with `avail_out == 0`) returns `Z_BUF_ERROR`. That is `< 0`, so the loop exits — but `Z_BUF_ERROR` is deliberately excluded from the "Uncompress failed" diagnostic (treated as non-fatal "buffer full"). Control reaches the final check with `dest_pos == uncompressedDataSize` and the function returns `true`, even though `Z_STREAM_END` was never reached and the trailing Adler-32 checksum was never validated.

Adding an explicit `err != Z_STREAM_END` rejection guarantees the entire stream (including its trailer) was consumed, closing the exact-size-truncation gap while keeping the informative byte-count message for the short-read case.
</details>

<!--
provenance: found via automated review on ITK's re-vendor of MetaIO 8c41a1d (InsightSoftwareConsortium/ITK#6692); issue Kitware/MetaIO#144
-->
